### PR TITLE
refactor: install eslint-plugin-unused-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "simple-import-sort",
     "deprecation",
     "import",
-    "prettier"
+    "prettier",
+    "unused-imports"
   ],
   "extends": [
     "plugin:@typescript-eslint/recommended",
@@ -107,12 +108,14 @@
     "import/newline-after-import": "off",
     "import/prefer-default-export": "off",
     "consistent-return": "off",
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": "error",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-function": "off",
     "no-empty-function": "off",
-    "no-unused-vars": "off",
     "require-await": "error",
     "no-useless-constructor": "off",
     "class-methods-use-this": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "eslint-plugin-security": "^1.7.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-switch-case": "^1.1.2",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "husky": "^8.0.3",
         "jest": "29.5.0",
         "lint-staged": "^13.2.0",
@@ -6585,6 +6586,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint-plugin-security": "^1.7.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-switch-case": "^1.1.2",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.3",
     "jest": "29.5.0",
     "lint-staged": "^13.2.0",

--- a/src/helpers/db-response.helper.ts
+++ b/src/helpers/db-response.helper.ts
@@ -32,7 +32,7 @@ export class DbResponseHelper {
     const { propertiesMap } = repository.metadata;
     return dbResults.map((dbEntry) => {
       const renamedObject = {};
-      Object.keys(propertiesMap).forEach((key, index) => {
+      Object.keys(propertiesMap).forEach((key) => {
         // key is safe because it is commint from NestJs entity class, not user input.
         if (fieldNameMap[`${key}`]) {
           renamedObject[`${key}`] = dbEntry[fieldNameMap[`${key}`]];

--- a/src/modules/yield-rates/yield-rates.controller.test.ts
+++ b/src/modules/yield-rates/yield-rates.controller.test.ts
@@ -1,17 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import Chance from 'chance';
-import { Response } from 'express';
 
 import { YieldRatesController } from './yield-rates.controller';
 import { YieldRatesService } from './yield-rates.service';
 
 const chance = new Chance();
-
-// Minimal mock of express Response. "as any" is required to get around Typescript type check.
-// TODO: this can be rewritten to use mock library.
-const mockResponseObject = {
-  set: jest.fn().mockReturnValue({}),
-} as any as Response;
 
 describe('YieldRatesController', () => {
   let yieldRatesController: YieldRatesController;

--- a/test/createApp.ts
+++ b/test/createApp.ts
@@ -1,4 +1,4 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { MainModule } from '../src/main.module';


### PR DESCRIPTION
## Introduction
We should keep the code free from unused imports and variables. On TFS, we installed `eslint-plugin-unused-imports` so the linter can help us do this.

## Resolution
- I installed `eslint-plugin-unused-imports`
- I added the plugin to `.eslintrc.json`
- I removed all existing unused imports and variables