### PR TITLE
fix: bug apim-203 make optional fields optional in spec

### DIFF
--- a/src/modules/currencies/dto/currency-exchange.dto.ts
+++ b/src/modules/currencies/dto/currency-exchange.dto.ts
@@ -17,6 +17,7 @@ export class GetCurrencyExchangeDto {
   readonly target: string;
 
   @ApiProperty({
+    required: false,
     example: '2021-01-26',
     description: 'Retrieve the exchange rate for a specific date',
   })

--- a/src/modules/premium-schedules/dto/create-premium-schedule.dto.ts
+++ b/src/modules/premium-schedules/dto/create-premium-schedule.dto.ts
@@ -71,7 +71,11 @@ export class CreatePremiumScheduleDto {
 
   @IsNumber()
   @IsOptional()
-  @ApiProperty({ example: null, description: 'Optional EWCS Exposure ONLY, this is the cumulative amount drawn on the first disbursement. NULL if not EWCS' })
+  @ApiProperty({
+    required: false,
+    example: null,
+    description: 'Optional EWCS Exposure ONLY, this is the cumulative amount drawn on the first disbursement. NULL if not EWCS',
+  })
   readonly cumulativeAmount: number;
 
   @IsNumber()

--- a/src/modules/yield-rates/dto/get-yield-rates-query.dto.ts
+++ b/src/modules/yield-rates/dto/get-yield-rates-query.dto.ts
@@ -9,6 +9,7 @@ export class GetYieldRatesQueryDto {
   @ApiProperty({
     example: '2023-03-01',
     description: 'Filter yield rates for specific date. Can go back to 2010-03-15',
+    required: false,
   })
   public searchDate: string;
 }


### PR DESCRIPTION
### Introduction
GET /mdm/api/v1/yield-rates    - was returning 404 if called in Azure API manager.
GET /mdm/api/v1/yield-rates?searchDate=2023-01-01 - was working fine

### Resolution
- GET /mdm/api/v1/yield-rates   has optional query parameter "searchDate".
- searchDate was optional for NodeJs, but was not optional in OpenAPI spec. 
- Azure API manager (APIM) added extra check for required parameters
  - APIM returned 404 if required parameter was not present
  - NestJs was not called
- Other endpoint/parameters were affected

