### PR TITLE
feat(APIM-310): added new query parameter 'search' to GET /markets

### DIFF
--- a/src/modules/exposure-period/exposure-period.service.ts
+++ b/src/modules/exposure-period/exposure-period.service.ts
@@ -19,7 +19,7 @@ export class ExposurePeriodService {
       // TODO: SP USP_MDM_READ_EXPOSURE_PERIOD is not using data/tables from DB. Calculation could be moved to Javascript.
       const results = await this.mdmDataSource.query('USP_MDM_READ_EXPOSURE_PERIOD @0, @1, @2', [startDate, endDate, productGroup]);
 
-      if (!results.Length || typeof results[0].EXPOSURE_PERIOD === 'undefined') {
+      if (!results.length || typeof results[0].EXPOSURE_PERIOD === 'undefined') {
         throw new InternalServerErrorException('No exposure period result from USP_MDM_READ_EXPOSURE_PERIOD');
       }
 

--- a/src/modules/markets/dto/markets-query.dto.ts
+++ b/src/modules/markets/dto/markets-query.dto.ts
@@ -13,4 +13,12 @@ export class MarketsQueryDto {
     enum: QueryParamActiveEnum,
   })
   public active: string;
+
+  @IsOptional()
+  @ApiProperty({
+    required: false,
+    example: 'korea',
+    description: 'Optional filtering by fields "marketName" or "isoCode". Partial matches are allowed and search is not case sensitive',
+  })
+  public search: string;
 }

--- a/src/modules/markets/markets.controller.ts
+++ b/src/modules/markets/markets.controller.ts
@@ -20,6 +20,6 @@ export class MarketsController {
     type: MarketEntity,
   })
   findAll(@Query() query: MarketsQueryDto): Promise<MarketEntity[]> {
-    return this.marketService.findAll(query.active);
+    return this.marketService.find(query.active, query.search);
   }
 }

--- a/src/modules/markets/markets.service.ts
+++ b/src/modules/markets/markets.service.ts
@@ -15,7 +15,7 @@ export class MarketsService {
     private readonly marketsRepository: Repository<MarketEntity>,
   ) {}
 
-  async findAll(active?: string): Promise<MarketEntity[]> {
+  async find(active?: string, search?: string): Promise<MarketEntity[]> {
     try {
       let results = await this.marketsRepository.query('CIS_USP_READ_MARKETS');
 
@@ -25,6 +25,14 @@ export class MarketsService {
         } else {
           results = results.filter((results: { ACTIVE_IND: string }) => results.ACTIVE_IND !== 'Y');
         }
+      }
+
+      if (search) {
+        const searchLowerCase = search.toLowerCase();
+        results = results.filter(
+          (results: { COUNTRY_NAME: string; ISO_CODE: string }) =>
+            results.COUNTRY_NAME.toLowerCase().indexOf(searchLowerCase) !== -1 || results.ISO_CODE.toLowerCase().indexOf(searchLowerCase) !== -1,
+        );
       }
 
       const fieldMap = DbResponseHelper.getApiNameToDbNameMap(this.marketsRepository);

--- a/test/markets/markets.api-test.ts
+++ b/test/markets/markets.api-test.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 
 import { Api } from '../api';
 import { CreateApp } from '../createApp';
+import { TEST_CONSTANTS } from '../test-constants';
 
 describe('Markets', () => {
   let app: INestApplication;
@@ -106,6 +107,85 @@ describe('Markets', () => {
     expect(status).toBe(400);
     expect(body.error).toMatch('Bad Request');
     expect(body.message[0]).toMatch('active must be one of the following values: Y, N');
+  });
+
+  // Testing "search" query parameter
+
+  it(`GET /markets?search=Aus`, async () => {
+    const { status, body } = await api.get('/markets?search=Aus');
+
+    expect(status).toBe(200);
+    expect(body).toEqual(expect.arrayContaining([expect.objectContaining(marketSchema)]));
+    expect(body).toHaveLength(2);
+  });
+
+  it(`GET /markets?search=AUT`, async () => {
+    const { status, body } = await api.get('/markets?search=AUT');
+
+    expect(status).toBe(200);
+
+    expect(body).toEqual(expect.arrayContaining([expect.objectContaining(marketSchema)]));
+    expect(body[0].marketName).toBe('Austria');
+    expect(body[0].isoCode).toBe('AUT');
+  });
+
+  it(`test that query param search is not case sensitive`, async () => {
+    const { status, body } = await api.get('/markets?search=Aus');
+    const lowerCaseResponse = await api.get('/markets?search=aus');
+
+    expect(status).toBe(200);
+    expect(lowerCaseResponse.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body).toEqual(lowerCaseResponse.body);
+  });
+
+  it(`GET /markets?active=Y&search=Aus`, async () => {
+    const { status, body } = await api.get('/markets?active=Y&search=Aus');
+
+    expect(status).toBe(200);
+    expect(body).toEqual(expect.arrayContaining([expect.objectContaining(marketSchema)]));
+  });
+
+  it(`GET /markets?active=N&search=Aus`, async () => {
+    const { status, body } = await api.get('/markets?active=N&search=Aus');
+
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it(`GET /markets?search=undefined`, async () => {
+    const { status, body } = await api.get('/markets?search=undefined');
+
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it(`GET /markets?search=null`, async () => {
+    const { status, body } = await api.get('/markets?search=null');
+
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it(`GET /markets?search=`, async () => {
+    const { status, body } = await api.get('/markets?search=');
+
+    expect(status).toBe(200);
+    expect(body).toEqual(expect.arrayContaining([expect.objectContaining(marketSchema)]));
+  });
+
+  it(`GET /markets?search=${TEST_CONSTANTS.SPECIAL_CHARACTERS}`, async () => {
+    const { status, body } = await api.get(`/markets?search=${TEST_CONSTANTS.SPECIAL_CHARACTERS}`);
+
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it(`GET /markets?search=%20%20%20`, async () => {
+    const { status, body } = await api.get('/markets?search=%20%20%20');
+
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
   });
 
   afterAll(async () => {

--- a/test/test-constants.ts
+++ b/test/test-constants.ts
@@ -1,0 +1,3 @@
+export const TEST_CONSTANTS = {
+  SPECIAL_CHARACTERS: '!"£!"',
+};


### PR DESCRIPTION
### Introduction
- During MDM integration with DTFS we noticed that they use GET /Countries endpoint.
- This PR adds enough functionality to GET /markets endpoint that it can replace GET /countries for DTFS

### Resolution
- Added query parameter 'search' to GET /markets
- Works in similar manner like in Mulesoft implementation
  - parameter is optional
  - search allows partial matches
  - it is not case sensitive
- Node JS keeps getting all markets from SP and filters results later, overhead is minimal as we have just 236 markets
- old endpoint `/countries` was getting data from CEDAR, `/markets` is getting data from CIS DB. They are very similar, but some differences might occur.

### Miscellaneous 
- fixed GET /exposure-period