### PR TITLE
fix(DTFS2-7223): ensure registration number regex only accepts 8-character strings

### DIFF
--- a/src/constants/companies.constant.ts
+++ b/src/constants/companies.constant.ts
@@ -5,6 +5,6 @@ export const COMPANIES = {
   },
   REGEX: {
     // This Companies House registration number regex was copied from the DTFS codebase.
-    COMPANIES_HOUSE_REGISTRATION_NUMBER: /^(([A-Z]{2}|[A-Z]\d|\d{2})(\d{5,6}|\d{4,5}[A-Z]))$/,
+    COMPANIES_HOUSE_REGISTRATION_NUMBER: /^(([A-Z]{2}|[A-Z]\d|\d{2})(\d{6}|\d{5}[A-Z]))$/,
   },
 };

--- a/src/modules/companies/dto/get-company-by-registration-number-query.dto.ts
+++ b/src/modules/companies/dto/get-company-by-registration-number-query.dto.ts
@@ -6,11 +6,11 @@ export class GetCompanyByRegistrationNumberQuery {
   @ApiProperty({
     description: 'The Companies House registration number of the company to find.',
     example: COMPANIES.EXAMPLES.COMPANIES_HOUSE_REGISTRATION_NUMBER,
-    minLength: 7,
+    minLength: 8,
     maxLength: 8,
     pattern: COMPANIES.REGEX.COMPANIES_HOUSE_REGISTRATION_NUMBER.source,
   })
-  @MinLength(7)
+  @MinLength(8)
   @MaxLength(8)
   @Matches(COMPANIES.REGEX.COMPANIES_HOUSE_REGISTRATION_NUMBER)
   public registrationNumber: string;

--- a/test/companies/get-company-by-registration-number.api-test.ts
+++ b/test/companies/get-company-by-registration-number.api-test.ts
@@ -59,35 +59,43 @@ describe('GET /companies?registrationNumber=', () => {
 
   it.each([
     {
-      registrationNumber: valueGenerator.stringOfNumericCharacters({ length: 6 }),
-      validationError: 'registrationNumber must be longer than or equal to 7 characters',
+      descriptionForTestName: 'too short',
+      registrationNumber: valueGenerator.stringOfNumericCharacters({ length: 7 }),
+      validationError: 'registrationNumber must be longer than or equal to 8 characters',
     },
     {
+      descriptionForTestName: 'too long',
       registrationNumber: valueGenerator.stringOfNumericCharacters({ length: 9 }),
       validationError: 'registrationNumber must be shorter than or equal to 8 characters',
     },
     {
+      descriptionForTestName: 'in the wrong format',
       registrationNumber: '0A000001',
-      validationError: 'registrationNumber must match /^(([A-Z]{2}|[A-Z]\\d|\\d{2})(\\d{5,6}|\\d{4,5}[A-Z]))$/ regular expression',
+      validationError: 'registrationNumber must match /^(([A-Z]{2}|[A-Z]\\d|\\d{2})(\\d{6}|\\d{5}[A-Z]))$/ regular expression',
     },
     {
+      descriptionForTestName: 'the empty string',
       registrationNumber: '',
-      validationError: 'registrationNumber must be longer than or equal to 7 characters',
+      validationError: 'registrationNumber must be longer than or equal to 8 characters',
     },
     {
+      descriptionForTestName: 'all spaces',
       registrationNumber: '        ',
-      validationError: 'registrationNumber must match /^(([A-Z]{2}|[A-Z]\\d|\\d{2})(\\d{5,6}|\\d{4,5}[A-Z]))$/ regular expression',
+      validationError: 'registrationNumber must match /^(([A-Z]{2}|[A-Z]\\d|\\d{2})(\\d{6}|\\d{5}[A-Z]))$/ regular expression',
     },
-  ])(`returns a 400 response with validation errors if postcode is '$registrationNumber'`, async ({ registrationNumber, validationError }) => {
-    const { status, body } = await api.get(getMdmPath(registrationNumber));
+  ])(
+    'returns a 400 response with the correct validation errors if the registration number is $descriptionForTestName',
+    async ({ registrationNumber, validationError }) => {
+      const { status, body } = await api.get(getMdmPath(registrationNumber));
 
-    expect(status).toBe(400);
-    expect(body).toMatchObject({
-      error: 'Bad Request',
-      message: expect.arrayContaining([validationError]),
-      statusCode: 400,
-    });
-  });
+      expect(status).toBe(400);
+      expect(body).toMatchObject({
+        error: 'Bad Request',
+        message: expect.arrayContaining([validationError]),
+        statusCode: 400,
+      });
+    },
+  );
 
   it(`returns a 404 response if the Companies House API returns a 404 response containing the error string 'company-profile-not-found'`, async () => {
     requestToGetCompanyByRegistrationNumber(companiesHousePath).reply(404, getCompanyCompaniesHouseNotFoundResponse);


### PR DESCRIPTION
## Introduction :pencil2:
The regex for Companies House registration numbers in MDM currently accepts 7 or 8 character strings, when in fact all valid registration numbers are 8-character strings. This is not a significant issue, as in DTFS (which consumes the /companies MDM endpoint) we restrict to 8 character strings, but we should still change this in MDM for consistency with DTFS.

## Resolution :heavy_check_mark:
- changed Companies House registration number regex and length validation, and associated tests.

