### PR TITLE
feat(FN-3664): add risk data to created customers

### DIFF
--- a/src/constants/customers.constant.ts
+++ b/src/constants/customers.constant.ts
@@ -3,5 +3,7 @@ export const CUSTOMERS = {
     COMPANYREG: '06012345',
     PARTYURN: '00302069',
     NAME: 'Testing Systems Ltd',
+    CREDIT_RISK_RATING: 'B+',
+    LOSS_GIVEN_DEFAULT: 50,
   },
 };

--- a/src/helpers/date-formatter.helper.test.ts
+++ b/src/helpers/date-formatter.helper.test.ts
@@ -1,17 +1,22 @@
 import { salesforceFormattedCurrentDate } from './date-formatter.helper';
 
 describe('salesforceFormattedCurrentDate function', () => {
-  const mockDate = new Date(2007, 3, 27);
-
-  beforeEach(() => {
-    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('should return the current date, formatted correctly', () => {
-    expect(salesforceFormattedCurrentDate()).toBe('2007-04-27');
+  const testCases = [
+    { mockDate: new Date('2007-04-27T00:00:00Z'), expected: '2007-04-27' },
+    { mockDate: new Date('2007-04-27'), expected: '2007-04-27' },
+    { mockDate: new Date(2007, 3, 27), expected: '2007-04-27' },
+    { mockDate: new Date('1970-01-01T12:34:56Z'), expected: '1970-01-01' },
+    { mockDate: new Date('9999-12-31'), expected: '9999-12-31' },
+    { mockDate: new Date('2020-02-29T00:00:00Z'), expected: '2020-02-29' }, // Leap year
+  ];
+
+  test.each(testCases)('should format the date $input as $expected', ({ mockDate, expected }) => {
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    expect(salesforceFormattedCurrentDate()).toBe(expected);
   });
 });

--- a/src/helpers/date-formatter.helper.test.ts
+++ b/src/helpers/date-formatter.helper.test.ts
@@ -1,0 +1,17 @@
+import { salesforceFormattedCurrentDate } from './date-formatter.helper';
+
+describe('salesforceFormattedCurrentDate function', () => {
+  const mockDate = new Date(2007, 3, 27);
+
+  beforeEach(() => {
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return the current date, formatted correctly', () => {
+    expect(salesforceFormattedCurrentDate()).toBe('2007-04-27');
+  });
+});

--- a/src/helpers/date-formatter.helper.ts
+++ b/src/helpers/date-formatter.helper.ts
@@ -9,5 +9,6 @@ export const salesforceFormattedCurrentDate = () => {
   const dd = String(today.getDate()).padStart(2, '0');
   const mm = String(today.getMonth() + 1).padStart(2, '0');
   const yyyy = String(today.getFullYear());
+
   return `${yyyy}-${mm}-${dd}`;
 };

--- a/src/helpers/date-formatter.helper.ts
+++ b/src/helpers/date-formatter.helper.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns the current date in the correct format for ingestion by the Salesforce sObject API.
+ *
+ * @returns {string} the current date in yyyy-mm-dd format
+ */
+
+export const salesforceFormattedCurrentDate = () => {
+  const today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = String(today.getFullYear());
+  return `${yyyy}-${mm}-${dd}`;
+};

--- a/src/modules/customers/customers.controller.test.ts
+++ b/src/modules/customers/customers.controller.test.ts
@@ -117,7 +117,7 @@ describe('CustomersController', () => {
   });
 
   describe('getOrCreateCustomer', () => {
-    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG, companyName: 'TEST NAME' };
+    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG, companyName: 'TEST NAME', probabilityOfDefault: 3 };
 
     const getOrCreateCustomerResponse: GetCustomersResponse = [
       {

--- a/src/modules/customers/customers.service.test.ts
+++ b/src/modules/customers/customers.service.test.ts
@@ -87,7 +87,7 @@ describe('CustomerService', () => {
   });
 
   describe('getOrCreateCustomer', () => {
-    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: '12345678', companyName: 'TEST NAME' };
+    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: '12345678', companyName: 'TEST NAME', probabilityOfDefault: 3 };
     const salesforceCreateCustomerResponse: CreateCustomerSalesforceResponseDto = {
       id: 'customer-id',
       errors: null,

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { CUSTOMERS } from '@ukef/constants';
 import { DunAndBradstreetService } from '@ukef/helper-modules/dun-and-bradstreet/dun-and-bradstreet.service';
 import { salesforceFormattedCurrentDate } from '@ukef/helpers/date-formatter.helper';
 import { GetCustomersInformaticaQueryDto } from '@ukef/modules/informatica/dto/get-customers-informatica-query.dto';
@@ -206,9 +207,9 @@ export class CustomersService {
       Party_URN__c: partyUrn,
       D_B_Number__c: dunsNumber,
       Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
-      CCM_Credit_Risk_Rating__c: 'B+',
+      CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
       CCM_Credit_Risk_Rating_Date__c: salesforceFormattedCurrentDate(),
-      CCM_Loss_Given_Default__c: 50,
+      CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
       CCM_Probability_of_Default__c: DTFSCustomerDto.probabilityOfDefault,
     };
 

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -70,7 +70,7 @@ export class CustomersService {
 
     try {
       const existingCustomersInInformatica = await this.informaticaService.getCustomers(backendQuery);
-      // If the customer exist in Informatica
+      // If the customer does exist in Informatica
       if (existingCustomersInInformatica?.[0]) {
         return await this.handleInformaticaResponse(res, DTFSCustomerDto, existingCustomersInInformatica);
       } else {
@@ -205,6 +205,9 @@ export class CustomersService {
       Party_URN__c: partyUrn,
       D_B_Number__c: dunsNumber,
       Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
+      CCM_Credit_Risk_Rating__c: 'B+',
+      CCM_Credit_Risk_Rating_Date__c: salesforceFormattedCurrentDate(),
+      CCM_Loss_Given_Default__c: 50,
     };
 
     const salesforceCreateCustomerResponse: CreateCustomerSalesforceResponseDto = await this.salesforceService.createCustomer(createCustomerDto);
@@ -221,4 +224,12 @@ export class CustomersService {
       },
     ];
   }
+}
+
+function salesforceFormattedCurrentDate(): string {
+  const today = new Date();
+  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const yyyy = String(today.getFullYear());
+  return `${yyyy}-${mm}-${dd}`;
 }

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { DunAndBradstreetService } from '@ukef/helper-modules/dun-and-bradstreet/dun-and-bradstreet.service';
+import { salesforceFormattedCurrentDate } from '@ukef/helpers/date-formatter.helper';
 import { GetCustomersInformaticaQueryDto } from '@ukef/modules/informatica/dto/get-customers-informatica-query.dto';
 import { InformaticaService } from '@ukef/modules/informatica/informatica.service';
 import { SalesforceService } from '@ukef/modules/salesforce/salesforce.service';
@@ -225,12 +226,4 @@ export class CustomersService {
       },
     ];
   }
-}
-
-function salesforceFormattedCurrentDate(): string {
-  const today = new Date();
-  const dd = String(today.getDate()).padStart(2, '0');
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const yyyy = String(today.getFullYear());
-  return `${yyyy}-${mm}-${dd}`;
 }

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -208,6 +208,7 @@ export class CustomersService {
       CCM_Credit_Risk_Rating__c: 'B+',
       CCM_Credit_Risk_Rating_Date__c: salesforceFormattedCurrentDate(),
       CCM_Loss_Given_Default__c: 50,
+      CCM_Probability_of_Default__c: DTFSCustomerDto.probabilityOfDefault,
     };
 
     const salesforceCreateCustomerResponse: CreateCustomerSalesforceResponseDto = await this.salesforceService.createCustomer(createCustomerDto);

--- a/src/modules/customers/dto/create-customer.dto.ts
+++ b/src/modules/customers/dto/create-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, Length, MaxLength, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, Length, MaxLength, MinLength } from 'class-validator';
 
 export class CreateCustomerDto {
   @ApiProperty({ description: 'Account Name' })
@@ -25,4 +25,19 @@ export class CreateCustomerDto {
   @MinLength(8)
   @MaxLength(10)
   Company_Registration_Number__c: string;
+
+  @ApiProperty({ description: 'Credit Risk Rating' })
+  @IsString()
+  @IsNotEmpty()
+  CCM_Credit_Risk_Rating__c: string;
+
+  @ApiProperty({ description: 'Credit Risk Rating Date' })
+  @IsString()
+  @IsNotEmpty()
+  CCM_Credit_Risk_Rating_Date__c: string;
+
+  @ApiProperty({ description: 'Loss Given Default' })
+  @IsNumber()
+  @IsNotEmpty()
+  CCM_Loss_Given_Default__c: number;
 }

--- a/src/modules/customers/dto/create-customer.dto.ts
+++ b/src/modules/customers/dto/create-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, Length, MaxLength, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, Length, Max, MaxLength, Min, MinLength } from 'class-validator';
 
 export class CreateCustomerDto {
   @ApiProperty({ description: 'Account Name' })
@@ -39,10 +39,14 @@ export class CreateCustomerDto {
   @ApiProperty({ description: 'Loss Given Default' })
   @IsNumber()
   @IsNotEmpty()
+  @Min(0)
+  @Max(100)
   CCM_Loss_Given_Default__c: number;
 
   @ApiProperty({ description: 'Probability of Default' })
   @IsNumber()
   @IsNotEmpty()
+  @Min(0)
+  @Max(100)
   CCM_Probability_of_Default__c: number;
 }

--- a/src/modules/customers/dto/create-customer.dto.ts
+++ b/src/modules/customers/dto/create-customer.dto.ts
@@ -31,8 +31,9 @@ export class CreateCustomerDto {
   @IsNotEmpty()
   CCM_Credit_Risk_Rating__c: string;
 
-  @ApiProperty({ description: 'Credit Risk Rating Date' })
+  @ApiProperty({ description: 'Credit Risk Rating Date (YYYY-MM-DD)' })
   @IsString()
+  @Length(10)
   @IsNotEmpty()
   CCM_Credit_Risk_Rating_Date__c: string;
 

--- a/src/modules/customers/dto/create-customer.dto.ts
+++ b/src/modules/customers/dto/create-customer.dto.ts
@@ -40,4 +40,9 @@ export class CreateCustomerDto {
   @IsNumber()
   @IsNotEmpty()
   CCM_Loss_Given_Default__c: number;
+
+  @ApiProperty({ description: 'Probability of Default' })
+  @IsNumber()
+  @IsNotEmpty()
+  CCM_Probability_of_Default__c: number;
 }

--- a/src/modules/customers/dto/dtfs-customer.dto.ts
+++ b/src/modules/customers/dto/dtfs-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
 
 export class DTFSCustomerDto {
   @ApiProperty({ description: 'Company Registration Number', minLength: 8, maxLength: 10 })
@@ -17,5 +17,7 @@ export class DTFSCustomerDto {
   @ApiProperty({ description: 'Probability of Default' })
   @IsNumber()
   @IsNotEmpty()
+  @Min(0)
+  @Max(100)
   probabilityOfDefault: number;
 }

--- a/src/modules/customers/dto/dtfs-customer.dto.ts
+++ b/src/modules/customers/dto/dtfs-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class DTFSCustomerDto {
   @ApiProperty({ description: 'Company Registration Number', minLength: 8, maxLength: 10 })
@@ -13,4 +13,9 @@ export class DTFSCustomerDto {
   @IsString()
   @IsNotEmpty()
   companyName: string;
+
+  @ApiProperty({ description: 'Probability of Default' })
+  @IsNumber()
+  @IsNotEmpty()
+  probabilityOfDefault: number;
 }

--- a/src/modules/salesforce/salesforce.service.test.ts
+++ b/src/modules/salesforce/salesforce.service.test.ts
@@ -60,6 +60,10 @@ describe('SalesforceService', () => {
       Party_URN__c: '00312345',
       D_B_Number__c: '12341234',
       Company_Registration_Number__c: companyRegNo,
+      CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+      CCM_Credit_Risk_Rating__c: 'B+',
+      CCM_Loss_Given_Default__c: 50,
+      CCM_Probability_of_Default__c: 3,
     };
 
     const expectedHttpServicePostArgs: [string, body: CreateCustomerDto, object] = [
@@ -105,6 +109,10 @@ describe('SalesforceService', () => {
         Party_URN__c: null,
         D_B_Number__c: null,
         Company_Registration_Number__c: '12341234',
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: 'B+',
+        CCM_Loss_Given_Default__c: 50,
+        CCM_Probability_of_Default__c: null,
       };
 
       const typeError = new TypeError("Cannot read properties of undefined (reading 'pipe')");

--- a/src/modules/salesforce/salesforce.service.test.ts
+++ b/src/modules/salesforce/salesforce.service.test.ts
@@ -1,5 +1,6 @@
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
+import { CUSTOMERS } from '@ukef/constants';
 import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-generator';
 import { AxiosError, HttpStatusCode } from 'axios';
 import { when } from 'jest-when';
@@ -54,25 +55,61 @@ describe('SalesforceService', () => {
       errors: null,
       success: true,
     };
-
-    const query: CreateCustomerDto = {
+    const baseQuery = {
       Name: companyRegNo,
       Party_URN__c: '00312345',
       D_B_Number__c: '12341234',
       Company_Registration_Number__c: companyRegNo,
       CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
-      CCM_Credit_Risk_Rating__c: 'B+',
-      CCM_Loss_Given_Default__c: 50,
+      CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+      CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
       CCM_Probability_of_Default__c: 3,
     };
-
-    const expectedHttpServicePostArgs: [string, body: CreateCustomerDto, object] = [
+    const baseExpectedHttpServicePostArgs: [string, body: CreateCustomerDto, object] = [
       customerBasePath,
-      query,
+      baseQuery,
       { headers: { Authorization: 'Bearer ' + expectedAccessToken } },
     ];
 
-    it('sends a POST to the Salesforce /sobjects/Account endpoint with the specified request', async () => {
+    it.each([
+      baseQuery,
+      {
+        Name: companyRegNo,
+        Party_URN__c: '00312345',
+        D_B_Number__c: '12341234',
+        Company_Registration_Number__c: companyRegNo,
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+        CCM_Probability_of_Default__c: 0.0,
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: '00312345',
+        D_B_Number__c: '12341234',
+        Company_Registration_Number__c: companyRegNo,
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+        CCM_Probability_of_Default__c: 100.0,
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: '00312345',
+        D_B_Number__c: '12341234',
+        Company_Registration_Number__c: companyRegNo,
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: 'A+++',
+        CCM_Loss_Given_Default__c: 100,
+        CCM_Probability_of_Default__c: 14.1,
+      },
+    ])('sends a POST to the Salesforce /sobjects/Account endpoint with the specified request', async (query) => {
+      const expectedHttpServicePostArgs: [string, body: CreateCustomerDto, object] = [
+        customerBasePath,
+        query,
+        { headers: { Authorization: 'Bearer ' + expectedAccessToken } },
+      ];
+
       when(httpServicePost)
         .calledWith(...expectedHttpServicePostArgs)
         .mockReturnValueOnce(
@@ -94,27 +131,47 @@ describe('SalesforceService', () => {
     it('throws a SalesforceException if the request to Salesforce fails', async () => {
       const axiosRequestError = new AxiosError();
       when(httpServicePost)
-        .calledWith(...expectedHttpServicePostArgs)
+        .calledWith(...baseExpectedHttpServicePostArgs)
         .mockReturnValueOnce(throwError(() => axiosRequestError));
-      const getCustomersPromise = service.createCustomer(query);
+      const getCustomersPromise = service.createCustomer(baseQuery);
 
       await expect(getCustomersPromise).rejects.toBeInstanceOf(SalesforceException);
       await expect(getCustomersPromise).rejects.toThrow('Failed to create customer in Salesforce');
       await expect(getCustomersPromise).rejects.toHaveProperty('innerError', axiosRequestError);
     });
 
-    it('throws a TypeError if the request is malformed', async () => {
-      const malformedQuery: CreateCustomerDto = {
+    it.each([
+      {
         Name: companyRegNo,
         Party_URN__c: null,
         D_B_Number__c: null,
         Company_Registration_Number__c: '12341234',
         CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
-        CCM_Credit_Risk_Rating__c: 'B+',
-        CCM_Loss_Given_Default__c: 50,
+        CCM_Credit_Risk_Rating__c: null,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
         CCM_Probability_of_Default__c: null,
-      };
-
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: null,
+        D_B_Number__c: null,
+        Company_Registration_Number__c: '12341234',
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+        CCM_Probability_of_Default__c: 101,
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: null,
+        D_B_Number__c: null,
+        Company_Registration_Number__c: '12341234',
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+        CCM_Probability_of_Default__c: -1,
+      },
+    ])('throws a TypeError if the request is malformed', async (malformedQuery) => {
       const typeError = new TypeError("Cannot read properties of undefined (reading 'pipe')");
       const getCustomersPromise = service.createCustomer(malformedQuery);
 

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -808,9 +808,13 @@ components:
         companyName:
           type: string
           description: Company Name
+        probabilityOfDefault:
+          type: number
+          description: Probability of Default
       required:
         - companyRegistrationNumber
         - companyName
+        - probabilityOfDefault
     CreateUkefIdDto:
       type: object
       properties:


### PR DESCRIPTION
## Introduction :pencil2:
In discussion with Risk teams, they wanted Risk data to be added to newly created customers in Salesforce.
The APIM side will default Risk rating at B+ and Loss given default at 50%, and the DTFS side will pass Probability of Default through to APIM to be set on the new record.

## Resolution :heavy_check_mark:
Defaults the first two risk values, and sets the Probability of Default value to the value DTFS passes through.

## Miscellaneous :heavy_plus_sign:
A small doc typo fix I found.

