### PR TITLE
chore(APIM-612): companies house - isactive field

### DIFF
--- a/src/constants/companies.constant.ts
+++ b/src/constants/companies.constant.ts
@@ -7,4 +7,7 @@ export const COMPANIES = {
     // This Companies House registration number regex was copied from the DTFS codebase.
     COMPANIES_HOUSE_REGISTRATION_NUMBER: /^(([A-Z]{2}|[A-Z]\d|\d{2})(\d{6}|\d{5}[A-Z]))$/,
   },
+  STATUS: {
+    ACTIVE: 'active',
+  },
 };

--- a/src/modules/companies/companies.service.ts
+++ b/src/modules/companies/companies.service.ts
@@ -84,6 +84,7 @@ export class CompaniesService {
         region: address?.region,
       },
       industries: this.mapSicCodes(company.sic_codes, industryClasses),
+      isActive: company.company_status === 'active',
     };
   }
 

--- a/src/modules/companies/companies.service.ts
+++ b/src/modules/companies/companies.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { COMPANIES } from '@ukef/constants';
 import { CompaniesHouseService } from '@ukef/helper-modules/companies-house/companies-house.service';
 import { GetCompanyCompaniesHouseResponse } from '@ukef/helper-modules/companies-house/dto/get-company-companies-house-response.dto';
 import { CompaniesHouseNotFoundException } from '@ukef/helper-modules/companies-house/exception/companies-house-not-found.exception';
@@ -84,7 +85,7 @@ export class CompaniesService {
         region: address?.region,
       },
       industries: this.mapSicCodes(company.sic_codes, industryClasses),
-      isActive: company.company_status === 'active',
+      isActive: company?.company_status === COMPANIES.STATUS.ACTIVE,
     };
   }
 

--- a/src/modules/companies/dto/get-company-response.dto.ts
+++ b/src/modules/companies/dto/get-company-response.dto.ts
@@ -46,6 +46,7 @@ export class GetCompanyResponse {
   dateOfCreation: string;
   registeredAddress: RegisteredAddress;
   industries: Industry[];
+  isActive: boolean;
 }
 
 export class Industry {

--- a/test/support/generator/get-company-generator.ts
+++ b/test/support/generator/get-company-generator.ts
@@ -62,6 +62,7 @@ export class GetCompanyGenerator extends AbstractGenerator<CompanyValues, Genera
       ],
       industrySectorCode: this.valueGenerator.integer({ min: 1001, max: 1020 }),
       industrySectorName: this.valueGenerator.sentence({ words: 4 }),
+      isActive: this.valueGenerator.boolean(),
     };
   }
 
@@ -228,6 +229,7 @@ export class GetCompanyGenerator extends AbstractGenerator<CompanyValues, Genera
         country: v.country,
       },
       industries,
+      isActive: v.isActive,
     };
 
     const getCompanyCompaniesHouseOverseasCompanyResponse = structuredClone(getCompanyCompaniesHouseResponse);
@@ -297,6 +299,7 @@ interface CompanyValues {
   industryClassNames: string[];
   industrySectorCode: number;
   industrySectorName: string;
+  isActive: boolean;
 }
 
 interface GenerateOptions {


### PR DESCRIPTION
## Introduction :pencil2:
In order for Companies House to be consumed by other products/services, the integration should return an `isActive` field.

This will ensure that any product/service that needs to check if a company is active, will not need to perform a check on the `company_status` field and instead, can simply consume a `isActive` field.

## Resolution :heavy_check_mark:
- Update the service to return a `isActive` field.
- Update types and `GetCompanyGenerator`.
