### PR TITLE
feat(FN-3163): allow non gef deals

### DIFF
--- a/src/modules/customers/customers.controller.test.ts
+++ b/src/modules/customers/customers.controller.test.ts
@@ -117,7 +117,17 @@ describe('CustomersController', () => {
   });
 
   describe('getOrCreateCustomer', () => {
-    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG, companyName: 'TEST NAME', probabilityOfDefault: 3 };
+    const DTFSCustomerDtoWithProbabilityOfDefault: DTFSCustomerDto = {
+      companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG,
+      companyName: 'TEST NAME',
+      probabilityOfDefault: 3,
+    };
+
+    const DTFSCustomerDtoWithoutProbabilityOfDefault: DTFSCustomerDto = {
+      companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG,
+      companyName: 'TEST NAME',
+      probabilityOfDefault: undefined,
+    };
 
     const getOrCreateCustomerResponse: GetCustomersResponse = [
       {
@@ -131,19 +141,42 @@ describe('CustomersController', () => {
       },
     ];
 
-    it('creates a customer successfully and returns the response', async () => {
-      when(customersServiceGetOrCreateCustomer).calledWith(mockResponseObject, DTFSCustomerDto).mockResolvedValueOnce(getOrCreateCustomerResponse);
+    it('creates a customer successfully and returns the response when probabilityOfDefault is present', async () => {
+      when(customersServiceGetOrCreateCustomer)
+        .calledWith(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)
+        .mockResolvedValueOnce(getOrCreateCustomerResponse);
 
-      const response = await controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
+      const response = await controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault);
 
       expect(customersServiceGetOrCreateCustomer).toHaveBeenCalledTimes(1);
       expect(response).toEqual(getOrCreateCustomerResponse);
     });
 
     it('throws an error if the service fails to create a customer', async () => {
-      when(customersServiceGetOrCreateCustomer).calledWith(mockResponseObject, DTFSCustomerDto).mockRejectedValueOnce(new Error('Service Error'));
+      when(customersServiceGetOrCreateCustomer)
+        .calledWith(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)
+        .mockRejectedValueOnce(new Error('Service Error'));
 
-      await expect(controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
+      await expect(controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Service Error');
+    });
+
+    it('creates a customer successfully and returns the response when probabilityOfDefault is not present', async () => {
+      when(customersServiceGetOrCreateCustomer)
+        .calledWith(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)
+        .mockResolvedValueOnce(getOrCreateCustomerResponse);
+
+      const response = await controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault);
+
+      expect(customersServiceGetOrCreateCustomer).toHaveBeenCalledTimes(1);
+      expect(response).toEqual(getOrCreateCustomerResponse);
+    });
+
+    it('throws an error if the service fails to create a customer when probabilityOfDefault is not present', async () => {
+      when(customersServiceGetOrCreateCustomer)
+        .calledWith(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)
+        .mockRejectedValueOnce(new Error('Service Error'));
+
+      await expect(controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)).rejects.toThrow('Service Error');
     });
   });
 

--- a/src/modules/customers/customers.controller.test.ts
+++ b/src/modules/customers/customers.controller.test.ts
@@ -123,10 +123,15 @@ describe('CustomersController', () => {
       probabilityOfDefault: 3,
     };
 
-    const DTFSCustomerDtoWithoutProbabilityOfDefault: DTFSCustomerDto = {
+    const DTFSCustomerDtoWithFalsyProbabilityOfDefault: DTFSCustomerDto = {
       companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG,
       companyName: 'TEST NAME',
       probabilityOfDefault: undefined,
+    };
+
+    const DTFSCustomerDtoWithoutProbabilityOfDefault: DTFSCustomerDto = {
+      companyRegistrationNumber: CUSTOMERS.EXAMPLES.COMPANYREG,
+      companyName: 'TEST NAME',
     };
 
     const getOrCreateCustomerResponse: GetCustomersResponse = [
@@ -160,6 +165,17 @@ describe('CustomersController', () => {
       await expect(controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Service Error');
     });
 
+    it('creates a customer successfully and returns the response when probabilityOfDefault is falsy', async () => {
+      when(customersServiceGetOrCreateCustomer)
+        .calledWith(mockResponseObject, DTFSCustomerDtoWithFalsyProbabilityOfDefault)
+        .mockResolvedValueOnce(getOrCreateCustomerResponse);
+
+      const response = await controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithFalsyProbabilityOfDefault);
+
+      expect(customersServiceGetOrCreateCustomer).toHaveBeenCalledTimes(1);
+      expect(response).toEqual(getOrCreateCustomerResponse);
+    });
+
     it('creates a customer successfully and returns the response when probabilityOfDefault is not present', async () => {
       when(customersServiceGetOrCreateCustomer)
         .calledWith(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)
@@ -169,14 +185,6 @@ describe('CustomersController', () => {
 
       expect(customersServiceGetOrCreateCustomer).toHaveBeenCalledTimes(1);
       expect(response).toEqual(getOrCreateCustomerResponse);
-    });
-
-    it('throws an error if the service fails to create a customer when probabilityOfDefault is not present', async () => {
-      when(customersServiceGetOrCreateCustomer)
-        .calledWith(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)
-        .mockRejectedValueOnce(new Error('Service Error'));
-
-      await expect(controller.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithoutProbabilityOfDefault)).rejects.toThrow('Service Error');
     });
   });
 

--- a/src/modules/customers/customers.service.test.ts
+++ b/src/modules/customers/customers.service.test.ts
@@ -87,7 +87,16 @@ describe('CustomerService', () => {
   });
 
   describe('getOrCreateCustomer', () => {
-    const DTFSCustomerDto: DTFSCustomerDto = { companyRegistrationNumber: '12345678', companyName: 'TEST NAME', probabilityOfDefault: 3 };
+    const DTFSCustomerDtoWithProbabilityOfDefault: DTFSCustomerDto = {
+      companyRegistrationNumber: '12345678',
+      companyName: 'TEST NAME',
+      probabilityOfDefault: 3,
+    };
+    const DTFSCustomerDtoWithoutProbabilityOfDefault: DTFSCustomerDto = {
+      companyRegistrationNumber: '12345678',
+      companyName: 'TEST NAME',
+      probabilityOfDefault: undefined,
+    };
     const salesforceCreateCustomerResponse: CreateCustomerSalesforceResponseDto = {
       id: 'customer-id',
       errors: null,
@@ -123,18 +132,10 @@ describe('CustomerService', () => {
 
         it.each([
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: 3,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
           },
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: undefined,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
           },
         ])('returns the existing customer both with and without probability of default', async ({ DTFSCustomerDto }) => {
           when(informaticaServiceGetCustomers)
@@ -172,18 +173,10 @@ describe('CustomerService', () => {
 
           it.each([
             {
-              DTFSCustomerDto: {
-                companyRegistrationNumber: '12345678',
-                companyName: 'TEST NAME',
-                probabilityOfDefault: 3,
-              },
+              DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
             },
             {
-              DTFSCustomerDto: {
-                companyRegistrationNumber: '12345678',
-                companyName: 'TEST NAME',
-                probabilityOfDefault: undefined,
-              },
+              DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
             },
           ])(
             'creates a new customer using the legacy URN and returns the response if there are no errors both with and without probability of default',
@@ -224,11 +217,11 @@ describe('CustomerService', () => {
             when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
             when(informaticaServiceGetCustomers)
               .calledWith({
-                companyreg: DTFSCustomerDto.companyRegistrationNumber,
+                companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
               })
               .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-            await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
+            await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Service Error');
             expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
             expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
             expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
@@ -240,11 +233,11 @@ describe('CustomerService', () => {
             when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockRejectedValueOnce(new InternalServerErrorException());
             when(informaticaServiceGetCustomers)
               .calledWith({
-                companyreg: DTFSCustomerDto.companyRegistrationNumber,
+                companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
               })
               .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-            await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
+            await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Internal Server Error');
             expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
             expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
             expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
@@ -269,18 +262,10 @@ describe('CustomerService', () => {
 
         it.each([
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: 3,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
           },
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: undefined,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
           },
         ])(
           'creates a new customer with a new URN and returns the response if there are no errors both with and without probability of default',
@@ -321,11 +306,11 @@ describe('CustomerService', () => {
           when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
           when(informaticaServiceGetCustomers)
             .calledWith({
-              companyreg: DTFSCustomerDto.companyRegistrationNumber,
+              companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
             })
             .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
+          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Service Error');
           expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
           expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
           expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
@@ -333,18 +318,10 @@ describe('CustomerService', () => {
 
         it.each([
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: 3,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
           },
           {
-            DTFSCustomerDto: {
-              companyRegistrationNumber: '12345678',
-              companyName: 'TEST NAME',
-              probabilityOfDefault: undefined,
-            },
+            DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
           },
         ])(
           'continues creating customer with null PartyURN if numbers service fails to create a party urn both with and without probability of default',
@@ -384,11 +361,11 @@ describe('CustomerService', () => {
           when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockRejectedValueOnce(new InternalServerErrorException());
           when(informaticaServiceGetCustomers)
             .calledWith({
-              companyreg: DTFSCustomerDto.companyRegistrationNumber,
+              companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
             })
             .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
+          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Internal Server Error');
           expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
           expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
           expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
@@ -399,18 +376,10 @@ describe('CustomerService', () => {
     describe('when the customer does not exist', () => {
       it.each([
         {
-          DTFSCustomerDto: {
-            companyRegistrationNumber: '12345678',
-            companyName: 'TEST NAME',
-            probabilityOfDefault: 3,
-          },
+          DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
         },
         {
-          DTFSCustomerDto: {
-            companyRegistrationNumber: '12345678',
-            companyName: 'TEST NAME',
-            probabilityOfDefault: undefined,
-          },
+          DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
         },
       ])(
         'creates a customer successfully and returns the response if there are no errors both with and without probability of default',
@@ -450,11 +419,11 @@ describe('CustomerService', () => {
         when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
         when(informaticaServiceGetCustomers)
           .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
           })
           .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
+        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Service Error');
         expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
         expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
         expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
@@ -462,18 +431,10 @@ describe('CustomerService', () => {
 
       it.each([
         {
-          DTFSCustomerDto: {
-            companyRegistrationNumber: '12345678',
-            companyName: 'TEST NAME',
-            probabilityOfDefault: 3,
-          },
+          DTFSCustomerDto: DTFSCustomerDtoWithProbabilityOfDefault,
         },
         {
-          DTFSCustomerDto: {
-            companyRegistrationNumber: '12345678',
-            companyName: 'TEST NAME',
-            probabilityOfDefault: undefined,
-          },
+          DTFSCustomerDto: DTFSCustomerDtoWithoutProbabilityOfDefault,
         },
       ])(
         'continues creating customer with null PartyURN if numbers service fails to create a party urn both with and without probability of default',
@@ -513,11 +474,11 @@ describe('CustomerService', () => {
         when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockRejectedValueOnce(new InternalServerErrorException());
         when(informaticaServiceGetCustomers)
           .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
           })
           .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
 
-        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
+        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Internal Server Error');
         expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
         expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
         expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
@@ -528,11 +489,13 @@ describe('CustomerService', () => {
       it('throws an error if there is an InformaticaException', async () => {
         when(informaticaServiceGetCustomers)
           .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
           })
           .mockRejectedValueOnce(new InformaticaException('Failed to get customers in Informatica'));
 
-        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Failed to get customers in Informatica');
+        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow(
+          'Failed to get customers in Informatica',
+        );
 
         expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
         expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(0);
@@ -542,11 +505,11 @@ describe('CustomerService', () => {
       it('throws an error if the Informatica response does not contain valid customers', async () => {
         when(informaticaServiceGetCustomers)
           .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            companyreg: DTFSCustomerDtoWithProbabilityOfDefault.companyRegistrationNumber,
           })
           .mockResolvedValueOnce([]);
 
-        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
+        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDtoWithProbabilityOfDefault)).rejects.toThrow('Internal Server Error');
 
         expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
         expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(0);

--- a/src/modules/customers/customers.service.test.ts
+++ b/src/modules/customers/customers.service.test.ts
@@ -121,7 +121,22 @@ describe('CustomerService', () => {
           ],
         ];
 
-        it('returns the existing customer', async () => {
+        it.each([
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: 3,
+            },
+          },
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: undefined,
+            },
+          },
+        ])('returns the existing customer both with and without probability of default', async ({ DTFSCustomerDto }) => {
           when(informaticaServiceGetCustomers)
             .calledWith({
               companyreg: DTFSCustomerDto.companyRegistrationNumber,
@@ -155,35 +170,53 @@ describe('CustomerService', () => {
             ],
           ];
 
-          it('creates a new customer using the legacy URN and returns the response if there are no errors', async () => {
-            when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
-            when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
-            when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
-            when(informaticaServiceGetCustomers)
-              .calledWith({
-                companyreg: DTFSCustomerDto.companyRegistrationNumber,
-              })
-              .mockResolvedValueOnce(getCustomersResponse[0]);
+          it.each([
+            {
+              DTFSCustomerDto: {
+                companyRegistrationNumber: '12345678',
+                companyName: 'TEST NAME',
+                probabilityOfDefault: 3,
+              },
+            },
+            {
+              DTFSCustomerDto: {
+                companyRegistrationNumber: '12345678',
+                companyName: 'TEST NAME',
+                probabilityOfDefault: undefined,
+              },
+            },
+          ])(
+            'creates a new customer using the legacy URN and returns the response if there are no errors both with and without probability of default',
+            async ({ DTFSCustomerDto }) => {
+              when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
+              when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
+              when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
+              when(informaticaServiceGetCustomers)
+                .calledWith({
+                  companyreg: DTFSCustomerDto.companyRegistrationNumber,
+                })
+                .mockResolvedValueOnce(getCustomersResponse[0]);
 
-            await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
+              await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
 
-            expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
-            expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponseWithLegacyUrn);
-            expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
+              expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
+              expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponseWithLegacyUrn);
+              expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
 
-            expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
-              expect.objectContaining({
-                Name: DTFSCustomerDto.companyName,
-                D_B_Number__c: 'TEST DUNS_NUMBER',
-                Party_URN__c: 'SOME_LEGACY_URN',
-                Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
-              }),
-            );
+              expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  Name: DTFSCustomerDto.companyName,
+                  D_B_Number__c: 'TEST DUNS_NUMBER',
+                  Party_URN__c: 'SOME_LEGACY_URN',
+                  Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
+                }),
+              );
 
-            expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
-            expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-            expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
-          });
+              expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
+              expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+              expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
+            },
+          );
 
           it('throws an error if Salesforce service fails to create a customer', async () => {
             when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockRejectedValueOnce(new Error('Service Error'));
@@ -234,35 +267,53 @@ describe('CustomerService', () => {
           ],
         ];
 
-        it('creates a new customer with a new URN and returns the response if there are no errors', async () => {
-          when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
-          when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
-          when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
-          when(informaticaServiceGetCustomers)
-            .calledWith({
-              companyreg: DTFSCustomerDto.companyRegistrationNumber,
-            })
-            .mockResolvedValueOnce(getCustomersResponse[0]);
+        it.each([
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: 3,
+            },
+          },
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: undefined,
+            },
+          },
+        ])(
+          'creates a new customer with a new URN and returns the response if there are no errors both with and without probability of default',
+          async ({ DTFSCustomerDto }) => {
+            when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
+            when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
+            when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
+            when(informaticaServiceGetCustomers)
+              .calledWith({
+                companyreg: DTFSCustomerDto.companyRegistrationNumber,
+              })
+              .mockResolvedValueOnce(getCustomersResponse[0]);
 
-          await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
+            await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
 
-          expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
-          expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponse);
-          expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
+            expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
+            expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponse);
+            expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
 
-          expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
-            expect.objectContaining({
-              Name: DTFSCustomerDto.companyName,
-              D_B_Number__c: 'TEST DUNS_NUMBER',
-              Party_URN__c: 'TEST PARTY_URN',
-              Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
-            }),
-          );
+            expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
+              expect.objectContaining({
+                Name: DTFSCustomerDto.companyName,
+                D_B_Number__c: 'TEST DUNS_NUMBER',
+                Party_URN__c: 'TEST PARTY_URN',
+                Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
+              }),
+            );
 
-          expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
-          expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-          expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
-        });
+            expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
+            expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+            expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
+          },
+        );
 
         it('throws an error if Salesforce service fails to create a customer', async () => {
           when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockRejectedValueOnce(new Error('Service Error'));
@@ -280,7 +331,153 @@ describe('CustomerService', () => {
           expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
         });
 
-        it('continues creating customer with null PartyURN if numbers service fails to create a party urn', async () => {
+        it.each([
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: 3,
+            },
+          },
+          {
+            DTFSCustomerDto: {
+              companyRegistrationNumber: '12345678',
+              companyName: 'TEST NAME',
+              probabilityOfDefault: undefined,
+            },
+          },
+        ])(
+          'continues creating customer with null PartyURN if numbers service fails to create a party urn both with and without probability of default',
+          async ({ DTFSCustomerDto }) => {
+            when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
+            when(numbersServiceCreate).calledWith(expect.any(Object)).mockRejectedValueOnce(new InternalServerErrorException());
+            when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
+            when(informaticaServiceGetCustomers)
+              .calledWith({
+                companyreg: DTFSCustomerDto.companyRegistrationNumber,
+              })
+              .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
+
+            await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
+
+            expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
+            expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponseWithNoPartyUrn);
+            expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
+
+            expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
+              expect.objectContaining({
+                Name: DTFSCustomerDto.companyName,
+                D_B_Number__c: 'TEST DUNS_NUMBER',
+                Party_URN__c: null,
+                Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
+              }),
+            );
+            expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
+            expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+            expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
+          },
+        );
+
+        it('throws an error if Dun and Bradstreet service fails to return a DUNS number and does not call further services', async () => {
+          when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
+          when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
+          when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockRejectedValueOnce(new InternalServerErrorException());
+          when(informaticaServiceGetCustomers)
+            .calledWith({
+              companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            })
+            .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
+
+          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
+          expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+          expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
+          expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    describe('when the customer does not exist', () => {
+      it.each([
+        {
+          DTFSCustomerDto: {
+            companyRegistrationNumber: '12345678',
+            companyName: 'TEST NAME',
+            probabilityOfDefault: 3,
+          },
+        },
+        {
+          DTFSCustomerDto: {
+            companyRegistrationNumber: '12345678',
+            companyName: 'TEST NAME',
+            probabilityOfDefault: undefined,
+          },
+        },
+      ])(
+        'creates a customer successfully and returns the response if there are no errors both with and without probability of default',
+        async ({ DTFSCustomerDto }) => {
+          when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
+          when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
+          when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
+          when(informaticaServiceGetCustomers)
+            .calledWith({
+              companyreg: DTFSCustomerDto.companyRegistrationNumber,
+            })
+            .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
+
+          await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
+
+          expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
+          expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponse);
+          expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
+
+          expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
+            expect.objectContaining({
+              Name: DTFSCustomerDto.companyName,
+              D_B_Number__c: 'TEST DUNS_NUMBER',
+              Party_URN__c: 'TEST PARTY_URN',
+              Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
+            }),
+          );
+          expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
+          expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+          expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      it('throws an error if Salesforce service fails to create a customer', async () => {
+        when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockRejectedValueOnce(new Error('Service Error'));
+        when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
+        when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
+        when(informaticaServiceGetCustomers)
+          .calledWith({
+            companyreg: DTFSCustomerDto.companyRegistrationNumber,
+          })
+          .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
+
+        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
+        expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
+        expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([
+        {
+          DTFSCustomerDto: {
+            companyRegistrationNumber: '12345678',
+            companyName: 'TEST NAME',
+            probabilityOfDefault: 3,
+          },
+        },
+        {
+          DTFSCustomerDto: {
+            companyRegistrationNumber: '12345678',
+            companyName: 'TEST NAME',
+            probabilityOfDefault: undefined,
+          },
+        },
+      ])(
+        'continues creating customer with null PartyURN if numbers service fails to create a party urn both with and without probability of default',
+        async ({ DTFSCustomerDto }) => {
           when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
           when(numbersServiceCreate).calledWith(expect.any(Object)).mockRejectedValueOnce(new InternalServerErrorException());
           when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
@@ -307,100 +504,8 @@ describe('CustomerService', () => {
           expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
           expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
           expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
-        });
-
-        it('throws an error if Dun and Bradstreet service fails to return a DUNS number and does not call further services', async () => {
-          when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
-          when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
-          when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockRejectedValueOnce(new InternalServerErrorException());
-          when(informaticaServiceGetCustomers)
-            .calledWith({
-              companyreg: DTFSCustomerDto.companyRegistrationNumber,
-            })
-            .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
-
-          await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Internal Server Error');
-          expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-          expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(0);
-          expect(numbersServiceCreate).toHaveBeenCalledTimes(0);
-        });
-      });
-    });
-
-    describe('when the customer does not exist', () => {
-      it('creates a customer successfully and returns the response if there are no errors', async () => {
-        when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
-        when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
-        when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
-        when(informaticaServiceGetCustomers)
-          .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
-          })
-          .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
-
-        await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
-
-        expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
-        expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponse);
-        expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
-
-        expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            Name: DTFSCustomerDto.companyName,
-            D_B_Number__c: 'TEST DUNS_NUMBER',
-            Party_URN__c: 'TEST PARTY_URN',
-            Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
-          }),
-        );
-        expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
-        expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-        expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
-      });
-
-      it('throws an error if Salesforce service fails to create a customer', async () => {
-        when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockRejectedValueOnce(new Error('Service Error'));
-        when(numbersServiceCreate).calledWith(expect.any(Object)).mockResolvedValueOnce(createUkefIdResponse);
-        when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
-        when(informaticaServiceGetCustomers)
-          .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
-          })
-          .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
-
-        await expect(service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto)).rejects.toThrow('Service Error');
-        expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
-        expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-        expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
-      });
-
-      it('continues creating customer with null PartyURN if numbers service fails to create a party urn', async () => {
-        when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);
-        when(numbersServiceCreate).calledWith(expect.any(Object)).mockRejectedValueOnce(new InternalServerErrorException());
-        when(dunAndBradstreetServiceGetDunsNumber).calledWith(expect.any(String)).mockResolvedValueOnce(dunAndBradstreetGetDunsNumberResponse);
-        when(informaticaServiceGetCustomers)
-          .calledWith({
-            companyreg: DTFSCustomerDto.companyRegistrationNumber,
-          })
-          .mockRejectedValueOnce(new NotFoundException('Customer not found.'));
-
-        await service.getOrCreateCustomer(mockResponseObject, DTFSCustomerDto);
-
-        expect(mockResponseObject.json).toHaveBeenCalledTimes(1);
-        expect(mockResponseObject.json).toHaveBeenCalledWith(createCustomerResponseWithNoPartyUrn);
-        expect(mockResponseObject.status).toHaveBeenCalledWith(HttpStatusCode.Created);
-
-        expect(salesforceServiceCreateCustomer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            Name: DTFSCustomerDto.companyName,
-            D_B_Number__c: 'TEST DUNS_NUMBER',
-            Party_URN__c: null,
-            Company_Registration_Number__c: DTFSCustomerDto.companyRegistrationNumber,
-          }),
-        );
-        expect(salesforceServiceCreateCustomer).toHaveBeenCalledTimes(1);
-        expect(dunAndBradstreetServiceGetDunsNumber).toHaveBeenCalledTimes(1);
-        expect(numbersServiceCreate).toHaveBeenCalledTimes(1);
-      });
+        },
+      );
 
       it('throws an error if Dun and Bradstreet service fails to return a DUNS number and does not call further services', async () => {
         when(salesforceServiceCreateCustomer).calledWith(expect.any(Object)).mockResolvedValueOnce(salesforceCreateCustomerResponse);

--- a/src/modules/customers/dto/create-customer.dto.ts
+++ b/src/modules/customers/dto/create-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, Length, Max, MaxLength, Min, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, Length, Max, MaxLength, Min, MinLength } from 'class-validator';
 
 export class CreateCustomerDto {
   @ApiProperty({ description: 'Account Name' })
@@ -45,9 +45,10 @@ export class CreateCustomerDto {
   CCM_Loss_Given_Default__c: number;
 
   @ApiProperty({ description: 'Probability of Default' })
+  @IsOptional()
   @IsNumber()
   @IsNotEmpty()
   @Min(0)
   @Max(100)
-  CCM_Probability_of_Default__c: number;
+  CCM_Probability_of_Default__c?: number;
 }

--- a/src/modules/customers/dto/dtfs-customer.dto.ts
+++ b/src/modules/customers/dto/dtfs-customer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, Max, MaxLength, Min, MinLength } from 'class-validator';
 
 export class DTFSCustomerDto {
   @ApiProperty({ description: 'Company Registration Number', minLength: 8, maxLength: 10 })
@@ -15,6 +15,7 @@ export class DTFSCustomerDto {
   companyName: string;
 
   @ApiProperty({ description: 'Probability of Default' })
+  @IsOptional()
   @IsNumber()
   @IsNotEmpty()
   @Min(0)

--- a/src/modules/customers/dto/dtfs-customer.dto.ts
+++ b/src/modules/customers/dto/dtfs-customer.dto.ts
@@ -20,5 +20,5 @@ export class DTFSCustomerDto {
   @IsNotEmpty()
   @Min(0)
   @Max(100)
-  probabilityOfDefault: number;
+  probabilityOfDefault?: number;
 }

--- a/src/modules/salesforce/salesforce.service.test.ts
+++ b/src/modules/salesforce/salesforce.service.test.ts
@@ -101,6 +101,15 @@ describe('SalesforceService', () => {
         CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
         CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
         CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: '00312345',
+        D_B_Number__c: '12341234',
+        Company_Registration_Number__c: companyRegNo,
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
         CCM_Probability_of_Default__c: 100.0,
       },
       {

--- a/src/modules/salesforce/salesforce.service.test.ts
+++ b/src/modules/salesforce/salesforce.service.test.ts
@@ -91,6 +91,16 @@ describe('SalesforceService', () => {
         CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
         CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
         CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
+        CCM_Probability_of_Default__c: undefined,
+      },
+      {
+        Name: companyRegNo,
+        Party_URN__c: '00312345',
+        D_B_Number__c: '12341234',
+        Company_Registration_Number__c: companyRegNo,
+        CCM_Credit_Risk_Rating_Date__c: '2007-03-27',
+        CCM_Credit_Risk_Rating__c: CUSTOMERS.EXAMPLES.CREDIT_RISK_RATING,
+        CCM_Loss_Given_Default__c: CUSTOMERS.EXAMPLES.LOSS_GIVEN_DEFAULT,
         CCM_Probability_of_Default__c: 100.0,
       },
       {


### PR DESCRIPTION
## Introduction :pencil2:
From QA testing it was recognised that it would be good to allow non-GEF deals to automatically create customers in Salesforce (as well as GEF deals which already have this behaviour implemented). The only blocker to this is that Probability of Default needs to be optional as non-GEF exporters don't have a Probability of Default entered.

## Resolution :heavy_check_mark:
Make Probability of Default optional.
