### PR TITLE
fix(file-upload): upload file as a buffer type

### DIFF
--- a/src/constants/govuk-notify.constant.ts
+++ b/src/constants/govuk-notify.constant.ts
@@ -11,7 +11,7 @@ export const GOVUK_NOTIFY = {
     RESPONSE_URI: 'https://api.notifications.service.gov.uk/v2/notifications/efd12345-1234-5678-9012-ee123456789f',
     TEMPLATE_ID: 'tmpl1234-1234-5678-9012-abcd12345678',
     TEMPLATE_URI: 'https://api.notifications.service.gov.uk/services/abc12345-a123-4567-8901-123456789012/templates/tmpl1234-1234-5678-9012-abcd12345678',
-    FILE: Buffer.from('example-file.xlsx'),
+    FILE: '<Buffer 43 31 2c 43 32 2c 43 33 0a 41 2c 42 2c 43 0a 44 2c 45 2c 46 0a 31 2c 32 2c 33 0a 34 2c 35 2c 36 0a>',
   },
   FIELD_LENGTHS: {
     TEMPLATE_ID: 36,

--- a/src/helper-modules/govuk-notify/govuk-notify.service.ts
+++ b/src/helper-modules/govuk-notify/govuk-notify.service.ts
@@ -9,6 +9,7 @@ import {
 import { PinoLogger } from 'nestjs-pino';
 import { NotifyClient } from 'notifications-node-client';
 
+import { convertStringToBuffer } from '../../helpers';
 import { PostEmailsRequestDto } from '../../modules/emails/dto/post-emails-request.dto';
 import { PostEmailsResponseDto } from './dto/post-emails-response.dto';
 
@@ -39,7 +40,8 @@ export class GovukNotifyService {
     const { personalisation } = postEmailsRequest;
 
     if (personalisation.file) {
-      personalisation.linkToFile = await notifyClient.prepareUpload(personalisation.file, { confirmEmailBeforeDownload: true });
+      const buffer = convertStringToBuffer(personalisation.file.toString());
+      personalisation.linkToFile = await notifyClient.prepareUpload(buffer, { confirmEmailBeforeDownload: true });
     }
 
     const notifyResponse = await notifyClient

--- a/src/helpers/convert-string-to-buffer.test.ts
+++ b/src/helpers/convert-string-to-buffer.test.ts
@@ -46,7 +46,7 @@ describe('convertStringToBuffer', () => {
     expect(result).toEqual(expectedBuffer);
   });
 
-  it('should return empty buffer for an empty string', () => {
+  it('should return an empty buffer for an empty string', () => {
     // Arrange
     const stringBuffer = '<Buffer>';
     const expectedBuffer = Buffer.from([]);

--- a/src/helpers/convert-string-to-buffer.test.ts
+++ b/src/helpers/convert-string-to-buffer.test.ts
@@ -1,0 +1,65 @@
+import { convertStringToBuffer } from './convert-string-to-buffer';
+
+describe('convertStringToBuffer', () => {
+  it('should convert string to buffer type', () => {
+    // Arrange
+    const stringBuffer = '<Buffer 43 31 2c 43 32 2c 43 33 0a 41 2c 42 2c 43 0a 44 2c 45 2c 46 0a 31 2c 32 2c 33 0a 34 2c 35 2c 36 0a>';
+    const expectedBuffer = Buffer.from([
+      0x43, 0x31, 0x2c, 0x43, 0x32, 0x2c, 0x43, 0x33, 0x0a, 0x41, 0x2c, 0x42, 0x2c, 0x43, 0x0a, 0x44, 0x2c, 0x45, 0x2c, 0x46, 0x0a, 0x31, 0x2c, 0x32, 0x2c,
+      0x33, 0x0a, 0x34, 0x2c, 0x35, 0x2c, 0x36, 0x0a,
+    ]);
+
+    // Act
+    const result = convertStringToBuffer(stringBuffer);
+
+    // Assert
+    expect(result).toEqual(expectedBuffer);
+  });
+
+  it('should convert string to buffer type with extra whitespaces', () => {
+    // Arrange
+    const stringBuffer = '<Buffer 43 31 2c 43 32 2c    43 33 0a 41 2c 42 2c 43 0a 44 2c 45 2c 46 0a 31 2c 32 2c 33 0a 34 2c 35 2c 36 0a>';
+    const expectedBuffer = Buffer.from([
+      0x43, 0x31, 0x2c, 0x43, 0x32, 0x2c, 0x43, 0x33, 0x0a, 0x41, 0x2c, 0x42, 0x2c, 0x43, 0x0a, 0x44, 0x2c, 0x45, 0x2c, 0x46, 0x0a, 0x31, 0x2c, 0x32, 0x2c,
+      0x33, 0x0a, 0x34, 0x2c, 0x35, 0x2c, 0x36, 0x0a,
+    ]);
+
+    // Act
+    const result = convertStringToBuffer(stringBuffer);
+
+    // Assert
+    expect(result).toEqual(expectedBuffer);
+  });
+
+  it('should convert string to buffer type with no whitespaces', () => {
+    // Arrange
+    const stringBuffer = '<Buffer 43312c43322c43330a412c422c430a442c452c460a312c322c330a342c352c360a>';
+    const expectedBuffer = Buffer.from([
+      0x43, 0x31, 0x2c, 0x43, 0x32, 0x2c, 0x43, 0x33, 0x0a, 0x41, 0x2c, 0x42, 0x2c, 0x43, 0x0a, 0x44, 0x2c, 0x45, 0x2c, 0x46, 0x0a, 0x31, 0x2c, 0x32, 0x2c,
+      0x33, 0x0a, 0x34, 0x2c, 0x35, 0x2c, 0x36, 0x0a,
+    ]);
+
+    // Act
+    const result = convertStringToBuffer(stringBuffer);
+
+    // Assert
+    expect(result).toEqual(expectedBuffer);
+  });
+
+  it('should return empty buffer for an empty string', () => {
+    // Arrange
+    const stringBuffer = '<Buffer>';
+    const expectedBuffer = Buffer.from([]);
+
+    // Act
+    const result = convertStringToBuffer(stringBuffer);
+
+    // Assert
+    expect(result).toEqual(expectedBuffer);
+  });
+
+  it('should throw an error for a non-string buffer', () => {
+    // Act & Assert
+    expect(() => convertStringToBuffer(null)).toThrow("Cannot read properties of null (reading 'replace')");
+  });
+});

--- a/src/helpers/convert-string-to-buffer.ts
+++ b/src/helpers/convert-string-to-buffer.ts
@@ -11,6 +11,6 @@
 export const convertStringToBuffer = (data: string): Buffer => {
   // Remove buffer string characters
   const hexString = data.replace('<Buffer ', '').replace('>', '').replace(/\s+/g, '');
-  // Conver string to Buffer
+  // Convert string to Buffer
   return Buffer.from(hexString, 'hex');
 };

--- a/src/helpers/convert-string-to-buffer.ts
+++ b/src/helpers/convert-string-to-buffer.ts
@@ -1,0 +1,16 @@
+/**
+ * Converts a string representation of a buffer to an actual Buffer object.
+ *
+ * This function takes a string that represents a buffer (e.g., "<Buffer 68 65 6c 6c 6f>")
+ * and converts it to a Buffer object. It removes the "<Buffer " and ">" parts of the string,
+ * as well as any whitespace, and then creates a Buffer from the resulting hex string.
+ *
+ * @param data - The string representation of the buffer.
+ * @returns A Buffer object created from the hex string.
+ */
+export const convertStringToBuffer = (data: string): Buffer => {
+  // Remove buffer string characters
+  const hexString = data.replace('<Buffer ', '').replace('>', '').replace(/\s+/g, '');
+  // Conver string to Buffer
+  return Buffer.from(hexString, 'hex');
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './convert-string-to-buffer';
 export * from './regex.helper';
 export * from './response-status.helper';
 export * from './transform-interceptor.helper';

--- a/src/modules/emails/dto/post-emails-request.dto.ts
+++ b/src/modules/emails/dto/post-emails-request.dto.ts
@@ -54,14 +54,12 @@ export class PostEmailsRequestDto {
   @IsString()
   @IsOptional()
   @MinLength(1)
-  @MaxLength(400)
   @ApiProperty({
     example: GOVUK_NOTIFY.EXAMPLES.FILE,
     description: `File for GovNotify to consume and generate a link to download with supported file types. The file size must be smaller than ${GOVUK_NOTIFY.FILE.SIZE.MAX}`,
     required: false,
     nullable: true,
     minLength: 1,
-    maxLength: 400,
   })
   readonly file?: string | null;
 }


### PR DESCRIPTION
## Introduction :pencil2:
Ensure file upload is send to GovNotify as a `Buffer` type instead of `string` type.

## Resolution :heavy_check_mark:
* Introduced `convertStringToBuffer` helper to convert string to buffer.
* Updated test mock to sample buffer (CSV file).
* Removed maximum length for `file` property.
* Updated test cases.
