### PR TITLE
feat(GIFT-12948): get business centres from ods

### DIFF
--- a/src/constants/business-centre.constant.ts
+++ b/src/constants/business-centre.constant.ts
@@ -1,0 +1,6 @@
+export const BUSINESS_CENTRE = {
+  EXAMPLES: {
+    CODE: 'DbB',
+    NAME: 'Dubai bank holidays',
+  },
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,7 @@
  * Following constants are served:
  *
  * Auth strategy
+ * Business centre
  * Companies module
  * Companies House helper module
  * Customers
@@ -17,6 +18,7 @@
  */
 
 export * from './auth.constant';
+export * from './business-centre.constant';
 export * from './companies.constant';
 export * from './companies-house.constant';
 export * from './customers.constant';

--- a/src/helpers/convert-string-to-buffer.ts
+++ b/src/helpers/convert-string-to-buffer.ts
@@ -11,6 +11,7 @@
 export const convertStringToBuffer = (data: string): Buffer => {
   // Remove buffer string characters
   const hexString = data.replace('<Buffer ', '').replace('>', '').replace(/\s+/g, '');
+
   // Convert string to Buffer
   return Buffer.from(hexString, 'hex');
 };

--- a/src/helpers/date-formatter.helper.test.ts
+++ b/src/helpers/date-formatter.helper.test.ts
@@ -5,6 +5,7 @@ describe('salesforceFormattedCurrentDate', () => {
     jest.restoreAllMocks();
   });
 
+  // Arrange
   const testCases = [
     { mockDate: new Date('2007-04-27T00:00:00Z'), expected: '2007-04-27' },
     { mockDate: new Date('2007-04-27'), expected: '2007-04-27' },
@@ -14,6 +15,7 @@ describe('salesforceFormattedCurrentDate', () => {
     { mockDate: new Date('2020-02-29T00:00:00Z'), expected: '2020-02-29' }, // Leap year
   ];
 
+  // Act & Assert
   test.each(testCases)('should format the date $input as $expected', ({ mockDate, expected }) => {
     jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
 

--- a/src/helpers/date-formatter.helper.test.ts
+++ b/src/helpers/date-formatter.helper.test.ts
@@ -1,6 +1,6 @@
 import { salesforceFormattedCurrentDate } from './date-formatter.helper';
 
-describe('salesforceFormattedCurrentDate function', () => {
+describe('salesforceFormattedCurrentDate', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/src/helpers/get-int-config.helper.test.ts
+++ b/src/helpers/get-int-config.helper.test.ts
@@ -4,6 +4,7 @@ import { getIntConfig } from './get-int-config';
 
 describe('getIntConfig', () => {
   describe('returns a value', () => {
+    // Arrange
     it.each([
       { value: undefined, defaultValue: 60, expectedResult: 60 },
       { value: '123', defaultValue: 60, expectedResult: 123 },
@@ -13,6 +14,7 @@ describe('getIntConfig', () => {
       { value: `${Number.MAX_SAFE_INTEGER}`, defaultValue: 60, expectedResult: Number.MAX_SAFE_INTEGER },
       { value: `-${Number.MAX_SAFE_INTEGER}`, defaultValue: 60, expectedResult: -Number.MAX_SAFE_INTEGER },
     ])('if input is "$value", returns $expectedResult', ({ value, defaultValue, expectedResult }) => {
+      // Act & Assert
       expect(getIntConfig(value, defaultValue)).toBe(expectedResult);
     });
   });
@@ -27,11 +29,14 @@ describe('getIntConfig', () => {
   });
 
   describe('throws an InvalidConfigException if environment variable type is not string', () => {
+    // Arrange
     it.each([12, true, null, false, /.*/, {}, [], 0xff, 0b101])(
       'throws InvalidConfigException for "%s" because environment variable type is not string',
       (value) => {
+        // Act
         const gettingTheConfig = () => getIntConfig(value as unknown as string);
 
+        // Assert
         expect(gettingTheConfig).toThrow(InvalidConfigException);
         expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be string.`);
       },
@@ -39,9 +44,11 @@ describe('getIntConfig', () => {
   });
 
   it('throws InvalidConfigException if environment variable and default value is missing', () => {
+    // Act
     const gettingTheConfig = () => getIntConfig(undefined);
 
+    // Assert
     expect(gettingTheConfig).toThrow(InvalidConfigException);
-    expect(gettingTheConfig).toThrow("Environment variable is missing and doesn't have default value.");
+    expect(gettingTheConfig).toThrow('Environment variable is missing and does not have default value.');
   });
 });

--- a/src/helpers/get-int-config.helper.test.ts
+++ b/src/helpers/get-int-config.helper.test.ts
@@ -38,7 +38,7 @@ describe('getIntConfig', () => {
 
         // Assert
         expect(gettingTheConfig).toThrow(InvalidConfigException);
-        expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be string.`);
+        expect(gettingTheConfig).toThrow(`Input environment variable type for ${value} should be a string.`);
       },
     );
   });

--- a/src/helpers/get-int-config.helper.test.ts
+++ b/src/helpers/get-int-config.helper.test.ts
@@ -2,8 +2,8 @@ import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
 
 import { getIntConfig } from './get-int-config';
 
-describe('GetIntConfig helper', () => {
-  describe('getIntConfig returns value', () => {
+describe('getIntConfig', () => {
+  describe('returns a value', () => {
     it.each([
       { value: undefined, defaultValue: 60, expectedResult: 60 },
       { value: '123', defaultValue: 60, expectedResult: 123 },
@@ -17,7 +17,7 @@ describe('GetIntConfig helper', () => {
     });
   });
 
-  describe('getIntConfig throws invalid integer exception', () => {
+  describe('throws an invalid integer exception', () => {
     it.each(['abc', '12.5', '20th', '0xFF', '0b101'])(`throws InvalidConfigException for "%s" because it is not valid integer`, (value) => {
       const gettingTheConfig = () => getIntConfig(value as unknown as string);
 
@@ -26,7 +26,7 @@ describe('GetIntConfig helper', () => {
     });
   });
 
-  describe('getIntConfig throws InvalidConfigException because environment variable type is not string', () => {
+  describe('throws an InvalidConfigException if environment variable type is not string', () => {
     it.each([12, true, null, false, /.*/, {}, [], 0xff, 0b101])(
       'throws InvalidConfigException for "%s" because environment variable type is not string',
       (value) => {

--- a/src/helpers/get-int-config.ts
+++ b/src/helpers/get-int-config.ts
@@ -4,12 +4,12 @@ import { InvalidConfigException } from '@ukef/config/invalid-config.exception';
 export const getIntConfig = (environmentVariable: string, defaultValue?: number): number => {
   if (typeof environmentVariable === 'undefined') {
     if (typeof defaultValue === 'undefined') {
-      throw new InvalidConfigException(`Environment variable is missing and doesn't have default value.`);
+      throw new InvalidConfigException(`Environment variable is missing and does not have default value.`);
     }
     return defaultValue;
   }
   if (typeof environmentVariable !== 'string') {
-    throw new InvalidConfigException(`Input environment variable type for ${environmentVariable} should be string.`);
+    throw new InvalidConfigException(`Input environment variable type for ${environmentVariable} should be a string.`);
   }
 
   const integer = parseInt(environmentVariable, 10);

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './convert-string-to-buffer';
+export * from './map-business-centres';
 export * from './regex.helper';
 export * from './response-status.helper';
 export * from './transform-interceptor.helper';

--- a/src/helpers/map-business-centres.test.ts
+++ b/src/helpers/map-business-centres.test.ts
@@ -1,0 +1,43 @@
+import { GetOdsBusinessCentreResponse } from '@ukef/modules/ods/dto';
+
+import { mapBusinessCentres } from './map-business-centres';
+
+const mockBusinessCentres: GetOdsBusinessCentreResponse[] = [
+  {
+    business_centre_code: 'A',
+    business_centre_name: 'Business centre A',
+  },
+  {
+    business_centre_code: 'B',
+    business_centre_name: 'Business centre B',
+  },
+  {
+    business_centre_code: 'C',
+    business_centre_name: 'Business centre C',
+  },
+];
+
+describe('mapBusinessCentres', () => {
+  it('should return an array of mapped business centres', () => {
+    // Act
+    const result = mapBusinessCentres(mockBusinessCentres);
+
+    // Assert
+    const expected = [
+      {
+        code: mockBusinessCentres[0].business_centre_code,
+        name: mockBusinessCentres[0].business_centre_name,
+      },
+      {
+        code: mockBusinessCentres[1].business_centre_code,
+        name: mockBusinessCentres[1].business_centre_name,
+      },
+      {
+        code: mockBusinessCentres[2].business_centre_code,
+        name: mockBusinessCentres[2].business_centre_name,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/helpers/map-business-centres.ts
+++ b/src/helpers/map-business-centres.ts
@@ -1,0 +1,12 @@
+import { GetOdsBusinessCentreMappedResponse, GetOdsBusinessCentreResponse } from '@ukef/modules/ods/dto';
+
+/**
+ * Map ODS business centres data into a nicer format.
+ * @param {GetOdsBusinessCentreResponse[]} Business centres
+ * @returns {GetOdsBusinessCentreMappedResponse[]}
+ */
+export const mapBusinessCentres = (businessCentres: GetOdsBusinessCentreResponse[]): GetOdsBusinessCentreMappedResponse[] =>
+  businessCentres.map((centre: GetOdsBusinessCentreResponse) => ({
+    code: centre.business_centre_code,
+    name: centre.business_centre_name,
+  }));

--- a/src/helpers/redact-strings-in-log-args.helper.test.ts
+++ b/src/helpers/redact-strings-in-log-args.helper.test.ts
@@ -9,12 +9,15 @@ describe('redactStringsInLogArgs', () => {
   describe('redactStringsInLogArgs', () => {
     const domain = valueGenerator.httpsUrl();
     const otherSensitiveField = valueGenerator.word();
+
     const message = `ConnectionError: Failed to connect to ${domain}, ${otherSensitiveField}`;
     const redactedMessage = `ConnectionError: Failed to connect to [RedactedDomain], [Redacted]`;
+
     const redactStrings = [
       { searchValue: domain, replaceValue: '[RedactedDomain]' },
       { searchValue: otherSensitiveField, replaceValue: '[Redacted]' },
     ];
+
     const args = [
       {
         message: message,
@@ -35,6 +38,7 @@ describe('redactStringsInLogArgs', () => {
         },
       },
     ];
+
     const expectedResult = [
       {
         message: redactedMessage,
@@ -57,22 +61,29 @@ describe('redactStringsInLogArgs', () => {
     ];
 
     it('replaces sensitive data in input object', () => {
-      const redacted = redactStringsInLogArgs(true, REDACT_STRING_PATHS, redactStrings, args);
+      // Act
+      const result = redactStringsInLogArgs(true, REDACT_STRING_PATHS, redactStrings, args);
 
-      expect(redacted).toStrictEqual(expectedResult);
+      // Assert
+      expect(result).toStrictEqual(expectedResult);
     });
 
     it('returns original input if redactLogs is set to false', () => {
-      const redacted = redactStringsInLogArgs(false, REDACT_STRING_PATHS, redactStrings, args);
+      // Act
+      const result = redactStringsInLogArgs(false, REDACT_STRING_PATHS, redactStrings, args);
 
-      expect(redacted).toStrictEqual(args);
+      // Assert
+      expect(result).toStrictEqual(args);
     });
 
     it('replaces sensitive data in input object using regex', () => {
+      // Arrange
       const redactStrings = [{ searchValue: /(Login failed for user ').*(')/g, replaceValue: '$1[Redacted]$2' }];
       const otherSensitiveValue = valueGenerator.word();
+
       const messageforRegex = `Connection error: Login failed for user '${otherSensitiveValue}'`;
       const redactedMessage = `Connection error: Login failed for user '[Redacted]'`;
+
       const args = [
         {
           message: messageforRegex,
@@ -82,6 +93,11 @@ describe('redactStringsInLogArgs', () => {
           },
         },
       ];
+
+      // Act
+      const result = redactStringsInLogArgs(true, REDACT_STRING_PATHS, redactStrings, args);
+
+      // Assert
       const expectedResult = [
         {
           message: redactedMessage,
@@ -92,12 +108,11 @@ describe('redactStringsInLogArgs', () => {
         },
       ];
 
-      const redacted = redactStringsInLogArgs(true, REDACT_STRING_PATHS, redactStrings, args);
-
-      expect(redacted).toStrictEqual(expectedResult);
+      expect(result).toStrictEqual(expectedResult);
     });
 
     it('replaces sensitive data in different input object', () => {
+      // Arrange
       const args = [
         {
           field1: message,
@@ -107,7 +122,14 @@ describe('redactStringsInLogArgs', () => {
           },
         },
       ];
-      const expectedResult = [
+
+      const redactPaths = ['field1', 'field2.field3'];
+
+      // Act
+      const result = redactStringsInLogArgs(true, redactPaths, redactStrings, args);
+
+      // Assert
+      const expected = [
         {
           field1: redactedMessage,
           field2: {
@@ -116,10 +138,8 @@ describe('redactStringsInLogArgs', () => {
           },
         },
       ];
-      const redactPaths = ['field1', 'field2.field3'];
-      const redacted = redactStringsInLogArgs(true, redactPaths, redactStrings, args);
 
-      expect(redacted).toStrictEqual(expectedResult);
+      expect(result).toStrictEqual(expected);
     });
   });
 });

--- a/src/helpers/redact-strings-in-log-args.helper.test.ts
+++ b/src/helpers/redact-strings-in-log-args.helper.test.ts
@@ -3,7 +3,7 @@ import { RandomValueGenerator } from '@ukef-test/support/generator/random-value-
 
 import { redactStringsInLogArgs } from './redact-strings-in-log-args.helper';
 
-describe('Redact errors helper', () => {
+describe('redactStringsInLogArgs', () => {
   const valueGenerator = new RandomValueGenerator();
 
   describe('redactStringsInLogArgs', () => {

--- a/src/helpers/regex.helper.test.ts
+++ b/src/helpers/regex.helper.test.ts
@@ -1,37 +1,35 @@
 import { regexToString } from './regex.helper';
 
-describe('Regex helper', () => {
-  describe('regexToString', () => {
-    it('replaces the leading and trailing forward slashes with an empty string', () => {
-      const regex = /test/;
-      const regexString = regexToString(regex);
+describe('regexToString', () => {
+  it('replaces the leading and trailing forward slashes with an empty string', () => {
+    const regex = /test/;
+    const regexString = regexToString(regex);
 
-      expect(regexString).toBe('test');
-      expect(new RegExp(regexString)).toEqual(regex);
-    });
+    expect(regexString).toBe('test');
+    expect(new RegExp(regexString)).toEqual(regex);
+  });
 
-    it('escapes regexp forward slashes inside a string', () => {
-      const regex = /test\/test/;
-      const regexString = regexToString(regex);
+  it('escapes regexp forward slashes inside a string', () => {
+    const regex = /test\/test/;
+    const regexString = regexToString(regex);
 
-      expect(regexString).toBe('test\\/test');
-      expect(new RegExp(regexString)).toEqual(regex);
-    });
+    expect(regexString).toBe('test\\/test');
+    expect(new RegExp(regexString)).toEqual(regex);
+  });
 
-    it('escapes multiple back slashes inside a string', () => {
-      const regex = /^(?!\s)[\w\-.()\s]+(?<![\s.])$/;
-      const regexString = regexToString(regex);
+  it('escapes multiple back slashes inside a string', () => {
+    const regex = /^(?!\s)[\w\-.()\s]+(?<![\s.])$/;
+    const regexString = regexToString(regex);
 
-      expect(regexString).toBe('^(?!\\s)[\\w\\-.()\\s]+(?<![\\s.])$');
-      expect(new RegExp(regexString)).toEqual(regex);
-    });
+    expect(regexString).toBe('^(?!\\s)[\\w\\-.()\\s]+(?<![\\s.])$');
+    expect(new RegExp(regexString)).toEqual(regex);
+  });
 
-    it('escapes forward slashes inside a string', () => {
-      const regex = /^[\w\-:/\\()\s]+$/;
-      const regexString = regexToString(regex);
+  it('escapes forward slashes inside a string', () => {
+    const regex = /^[\w\-:/\\()\s]+$/;
+    const regexString = regexToString(regex);
 
-      expect(regexString).toBe('^[\\w\\-:/\\\\()\\s]+$');
-      expect(new RegExp(regexString)).toEqual(regex);
-    });
+    expect(regexString).toBe('^[\\w\\-:/\\\\()\\s]+$');
+    expect(new RegExp(regexString)).toEqual(regex);
   });
 });

--- a/src/helpers/regex.helper.test.ts
+++ b/src/helpers/regex.helper.test.ts
@@ -2,33 +2,49 @@ import { regexToString } from './regex.helper';
 
 describe('regexToString', () => {
   it('replaces the leading and trailing forward slashes with an empty string', () => {
+    // Arrange
     const regex = /test/;
+
+    // Act
     const regexString = regexToString(regex);
 
+    // Assert
     expect(regexString).toBe('test');
     expect(new RegExp(regexString)).toEqual(regex);
   });
 
   it('escapes regexp forward slashes inside a string', () => {
+    // Arrange
     const regex = /test\/test/;
+
+    // Act
     const regexString = regexToString(regex);
 
+    // Assert
     expect(regexString).toBe('test\\/test');
     expect(new RegExp(regexString)).toEqual(regex);
   });
 
   it('escapes multiple back slashes inside a string', () => {
+    // Arrange
     const regex = /^(?!\s)[\w\-.()\s]+(?<![\s.])$/;
+
+    // Act
     const regexString = regexToString(regex);
 
+    // Assert
     expect(regexString).toBe('^(?!\\s)[\\w\\-.()\\s]+(?<![\\s.])$');
     expect(new RegExp(regexString)).toEqual(regex);
   });
 
   it('escapes forward slashes inside a string', () => {
+    // Arrange
     const regex = /^[\w\-:/\\()\s]+$/;
+
+    // Act
     const regexString = regexToString(regex);
 
+    // Assert
     expect(regexString).toBe('^[\\w\\-:/\\\\()\\s]+$');
     expect(new RegExp(regexString)).toEqual(regex);
   });

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -1,4 +1,8 @@
-// This helper function is used to convert the regex pattern to a string so that it can be used in the swagger documentation.
+/**
+ * Convert a a regex pattern into a string
+ * @param {RegExp} Regular expression
+ * @returns {String}
+ */
 export const regexToString = (regex: RegExp): string => {
   return regex.source;
 };

--- a/src/helpers/response-status.helper.test.ts
+++ b/src/helpers/response-status.helper.test.ts
@@ -13,6 +13,7 @@ describe('statusCheck', () => {
   });
 
   it('should return true when isAxiosError is true and status matches', () => {
+    // Arrange
     const error = {
       response: {
         status: HttpStatus.BAD_REQUEST,
@@ -21,12 +22,15 @@ describe('statusCheck', () => {
       message: 'Bad request',
     } as Error;
 
+    // Act
     const result = statusCheck({ error, status: HttpStatus.BAD_REQUEST });
 
+    // Assert
     expect(result).toBe(true);
   });
 
   it('should return false when isAxiosError is true but status does not match', () => {
+    // Arrange
     const error = {
       response: {
         status: HttpStatus.BAD_REQUEST,
@@ -35,12 +39,15 @@ describe('statusCheck', () => {
       message: 'Bad request',
     } as Error;
 
+    // Act
     const result = statusCheck({ error, status: HttpStatus.NOT_FOUND });
 
+    // Assert
     expect(result).toBe(false);
   });
 
   it('should return false when isAxiosError is false', () => {
+    // Arrange
     const error = {
       response: {
         status: HttpStatus.BAD_REQUEST,
@@ -51,16 +58,20 @@ describe('statusCheck', () => {
 
     (isAxiosError as unknown as jest.Mock).mockReturnValue(false);
 
+    // Act
     const result = statusCheck({ error, status: HttpStatus.BAD_REQUEST });
 
+    // Assert
     expect(result).toBe(false);
   });
 
   it('should return false when error does not have a response', () => {
     const error = {} as Error;
 
+    // Act
     const result = statusCheck({ error, status: HttpStatus.BAD_REQUEST });
 
+    // Assert
     expect(result).toBe(false);
   });
 });
@@ -71,6 +82,7 @@ describe('messageCheck', () => {
   });
 
   it('should return true when isAxiosError is true and message contains search string', () => {
+    // Arrange
     const error = {
       response: {
         data: {
@@ -84,12 +96,15 @@ describe('messageCheck', () => {
       message: 'Error',
     } as Error;
 
+    // Act
     const result = messageCheck({ error, search: 'Invalid Authorization' });
 
+    // Assert
     expect(result).toBe(true);
   });
 
   it('should return true when isAxiosError is true and message contains similar search string', () => {
+    // Arrange
     const error = {
       response: {
         data: {
@@ -103,12 +118,15 @@ describe('messageCheck', () => {
       message: 'Error',
     } as Error;
 
+    // Act
     const result = messageCheck({ error, search: 'Invalid Authorization header' });
 
+    // Assert
     expect(result).toBe(true);
   });
 
   it('should return false when isAxiosError is true but message does not contain search string', () => {
+    // Arrange
     const error = {
       response: {
         data: {
@@ -122,12 +140,15 @@ describe('messageCheck', () => {
       message: 'Error',
     } as Error;
 
+    // Act
     const result = messageCheck({ error, search: 'Not found' });
 
+    // Assert
     expect(result).toBe(false);
   });
 
   it('should return false when isAxiosError is false', () => {
+    // Arrange
     const error = {
       response: {
         data: {
@@ -143,20 +164,26 @@ describe('messageCheck', () => {
 
     (isAxiosError as unknown as jest.Mock).mockReturnValue(false);
 
+    // Act
     const result = messageCheck({ error, search: 'Invalid Authorization header' });
 
+    // Assert
     expect(result).toBe(false);
   });
 
   it('should return false when error does not have a response', () => {
+    // Arrange
     const error = {} as Error;
 
+    // Act
     const result = messageCheck({ error, search: 'Invalid Authorization header' });
 
+    // Assert
     expect(result).toBe(false);
   });
 
   it('should return false when error response does not contain data', () => {
+    // Arrange
     const error = {
       response: {
         data: undefined,
@@ -167,8 +194,10 @@ describe('messageCheck', () => {
       message: 'Invalid Authorization header',
     } as Error;
 
+    // Act
     const result = messageCheck({ error, search: 'Invalid Authorization header' });
 
+    // Assert
     expect(result).toBe(false);
   });
 });

--- a/src/modules/ods/dto/get-ods-business-centre-mapped-response.dto.ts
+++ b/src/modules/ods/dto/get-ods-business-centre-mapped-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BUSINESS_CENTRE } from '@ukef/constants';
+
+export class GetOdsBusinessCentreMappedResponse {
+  @ApiProperty({
+    description: 'Business centre code',
+    example: BUSINESS_CENTRE.EXAMPLES.CODE,
+  })
+  readonly code: string;
+
+  @ApiProperty({
+    description: 'Business centre name',
+    example: BUSINESS_CENTRE.EXAMPLES.NAME,
+  })
+  readonly name: string;
+}

--- a/src/modules/ods/dto/get-ods-business-centre-response.dto.ts
+++ b/src/modules/ods/dto/get-ods-business-centre-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { BUSINESS_CENTRE } from '@ukef/constants';
+
+export class GetOdsBusinessCentreResponse {
+  @ApiProperty({
+    description: 'Business centre code',
+    example: BUSINESS_CENTRE.EXAMPLES.CODE,
+  })
+  readonly business_centre_code: string;
+
+  @ApiProperty({
+    description: 'Business centre name',
+    example: BUSINESS_CENTRE.EXAMPLES.NAME,
+  })
+  readonly business_centre_name: string;
+}

--- a/src/modules/ods/dto/index.ts
+++ b/src/modules/ods/dto/index.ts
@@ -1,3 +1,5 @@
+export * from './get-ods-business-centre-mapped-response.dto';
+export * from './get-ods-business-centre-response.dto';
 export * from './get-ods-customer-param.dto';
 export * from './get-ods-customer-response.dto';
 export * from './get-ods-deal-param.dto';

--- a/src/modules/ods/dto/ods-payloads.dto.ts
+++ b/src/modules/ods/dto/ods-payloads.dto.ts
@@ -1,14 +1,14 @@
 /**
- * Customer Stored Procedure query params can be found here:
+ * Customer, Deal, Business centre Stored Procedure query params can be found here:
  * https://github.com/UK-Export-Finance/database-ods-datateam/blob/dev/t_apim/Stored%20Procedures/sp_ODS_get_customer.sql#L12
  * https://github.com/UK-Export-Finance/database-ods-datateam/blob/dev/t_apim/Stored%20Procedures/sp_ODS_get_deal.sql#L14
+ * https://github.com/UK-Export-Finance/database-ods-datateam/blob/dev/t_apim/Stored%20Procedures/sp_ODS_get_business_centre.sql#L12
+ * https://github.com/UK-Export-Finance/database-ods-datateam/blob/dev/t_apim/Stored%20Procedures/sp_ODS_get_business_centre_non_working_day.sql#L12
  */
-export type OdsCustomerStoredProcedureQueryParams = {
+export type OdsStoredProcedureQueryParams = {
   customer_party_unique_reference_number?: string;
   deal_code?: string;
 };
-
-export type OdsStoredProcedureQueryParams = OdsCustomerStoredProcedureQueryParams;
 
 /**
  * Stored Procedure input definition can be found here:
@@ -17,7 +17,7 @@ export type OdsStoredProcedureQueryParams = OdsCustomerStoredProcedureQueryParam
 export type OdsStoredProcedureInput = {
   query_method: string;
   query_object: OdsEntity;
-  query_page_size: number;
+  query_page_size?: number;
   query_page_index: number;
   query_parameters: OdsStoredProcedureQueryParams;
 };
@@ -37,6 +37,7 @@ export type OdsStoredProcedureOutputBody = {
 export const ODS_ENTITIES = {
   CUSTOMER: 'customer',
   DEAL: 'deal',
+  BUSINESS_CENTRE: 'business_centre',
 } as const;
 
 export type OdsEntity = (typeof ODS_ENTITIES)[keyof typeof ODS_ENTITIES];

--- a/src/modules/ods/ods.controller.ts
+++ b/src/modules/ods/ods.controller.ts
@@ -1,13 +1,28 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
-import { GetOdsCustomerParamDto, GetOdsCustomerResponse, GetOdsDealParamDto, GetOdsDealResponse } from './dto';
+import { GetOdsBusinessCentreMappedResponse, GetOdsCustomerParamDto, GetOdsCustomerResponse, GetOdsDealParamDto, GetOdsDealResponse } from './dto';
 import { OdsService } from './ods.service';
 
 @ApiTags('ods')
 @Controller('ods')
 export class OdsController {
   constructor(private readonly odsService: OdsService) {}
+
+  @Get('business-centres')
+  @ApiOperation({
+    summary: 'Get business centres from ODS',
+  })
+  @ApiOkResponse({
+    description: 'Business centres',
+    type: GetOdsBusinessCentreMappedResponse,
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error.',
+  })
+  getBusinessCentres(): Promise<GetOdsBusinessCentreMappedResponse[]> {
+    return this.odsService.getBusinessCentres();
+  }
 
   @Get('customers/:urn')
   @ApiOperation({

--- a/src/modules/ods/ods.controller.ts
+++ b/src/modules/ods/ods.controller.ts
@@ -18,6 +18,9 @@ export class OdsController {
     isArray: true,
     type: GetOdsBusinessCentreMappedResponse,
   })
+  @ApiBadRequestResponse({
+    description: 'Bad request.',
+  })
   @ApiInternalServerErrorResponse({
     description: 'Internal server error.',
   })

--- a/src/modules/ods/ods.controller.ts
+++ b/src/modules/ods/ods.controller.ts
@@ -15,6 +15,7 @@ export class OdsController {
   })
   @ApiOkResponse({
     description: 'Business centres',
+    isArray: true,
     type: GetOdsBusinessCentreMappedResponse,
   })
   @ApiInternalServerErrorResponse({

--- a/src/modules/ods/ods.service-findCustomer.test.ts
+++ b/src/modules/ods/ods.service-findCustomer.test.ts
@@ -1,0 +1,149 @@
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { CUSTOMERS } from '@ukef/constants';
+import { PinoLogger } from 'nestjs-pino';
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { ODS_ENTITIES, OdsStoredProcedureInput } from './dto/ods-payloads.dto';
+import { OdsService } from './ods.service';
+
+describe('OdsService - findCustomer', () => {
+  let service: OdsService;
+  let mockQueryRunner: jest.Mocked<QueryRunner>;
+  let mockDataSource: jest.Mocked<DataSource>;
+  const mockLogger = new PinoLogger({});
+
+  beforeEach(() => {
+    mockQueryRunner = {
+      query: jest.fn(),
+      release: jest.fn(),
+    } as unknown as jest.Mocked<QueryRunner>;
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as unknown as jest.Mocked<DataSource>;
+
+    service = new OdsService(mockDataSource, mockLogger);
+  });
+
+  const mockCustomer = { urn: CUSTOMERS.EXAMPLES.PARTYURN, name: 'Test Customer' };
+
+  const mockStoredProcedureOutput = `{
+    "query_request_id": "Test ID",
+    "message": "SUCCESS",
+    "status": "SUCCESS",
+    "total_result_count": 1,
+    "results": [
+      {
+        "customer_party_unique_reference_number": "${mockCustomer.urn}",
+        "customer_name": "${mockCustomer.name}",
+        "customer_companies_house_number": "12345678",
+        "customer_addresses": [
+          {
+            "customer_address_type": "Registered",
+            "customer_address_street": "Test Street",
+            "customer_address_postcode": "AA1 1BB",
+            "customer_address_country": "United Kingdom",
+            "customer_address_city": "Test City"
+          }
+        ]
+      }
+    ]
+  }`;
+
+  beforeEach(() => {
+    jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+  });
+
+  it('should call service.callOdsStoredProcedure', async () => {
+    // Act
+    await service.findCustomer(mockCustomer.urn);
+
+    // Assert
+    const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
+      entityToQuery: ODS_ENTITIES.CUSTOMER,
+      queryPageSize: 1,
+      queryParameters: { customer_party_unique_reference_number: mockCustomer.urn },
+    });
+
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
+  });
+
+  it('should return a customer', async () => {
+    // Act
+    const result = await service.findCustomer(mockCustomer.urn);
+
+    // Assert
+    expect(result).toEqual(mockCustomer);
+  });
+
+  describe('when the response from ODS does not have status as SUCCESS', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findCustomer(mockCustomer.urn);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a customer');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the response from ODS has total_result_count as 0', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findCustomer(mockCustomer.urn);
+
+      await expect(promise).rejects.toBeInstanceOf(NotFoundException);
+
+      const expected = new Error('No customer found');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the method goes into the catch handler', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findCustomer(mockCustomer.urn);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a customer');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when callOdsStoredProcedure throws an error', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
+
+      // Act & Assert
+      const promise = service.findCustomer(mockCustomer.urn);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a customer');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+});

--- a/src/modules/ods/ods.service-findDeal.test.ts
+++ b/src/modules/ods/ods.service-findDeal.test.ts
@@ -1,0 +1,142 @@
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { DEALS } from '@ukef/constants';
+import { PinoLogger } from 'nestjs-pino';
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { ODS_ENTITIES, OdsStoredProcedureInput } from './dto/ods-payloads.dto';
+import { OdsService } from './ods.service';
+
+describe('OdsService - findDeal', () => {
+  let service: OdsService;
+  let mockQueryRunner: jest.Mocked<QueryRunner>;
+  let mockDataSource: jest.Mocked<DataSource>;
+  const mockLogger = new PinoLogger({});
+
+  beforeEach(() => {
+    mockQueryRunner = {
+      query: jest.fn(),
+      release: jest.fn(),
+    } as unknown as jest.Mocked<QueryRunner>;
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as unknown as jest.Mocked<DataSource>;
+
+    service = new OdsService(mockDataSource, mockLogger);
+  });
+
+  const mockStoredProcedureOutput = `{
+      "query_request_id": "Test ID",
+      "message": "SUCCESS",
+      "status": "SUCCESS",
+      "total_result_count": 1,
+      "results": [
+        {
+          "deal_code": "${DEALS.EXAMPLES.ID}",
+          "deal_name": "${DEALS.EXAMPLES.NAME}",
+          "deal_type_description": "${DEALS.EXAMPLES.DESCRIPTION}"
+        }
+      ]
+    }`;
+
+  beforeEach(() => {
+    jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+  });
+
+  it('should call service.callOdsStoredProcedure', async () => {
+    // Act
+    await service.findDeal(DEALS.EXAMPLES.ID);
+
+    // Assert
+    const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
+      entityToQuery: ODS_ENTITIES.DEAL,
+      queryPageSize: 1,
+      queryParameters: { deal_code: DEALS.EXAMPLES.ID },
+    });
+
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
+  });
+
+  it('should return a deal', async () => {
+    // Act
+    const result = await service.findDeal(DEALS.EXAMPLES.ID);
+
+    // Assert
+    const expected = {
+      dealId: DEALS.EXAMPLES.ID,
+      name: DEALS.EXAMPLES.NAME,
+      description: DEALS.EXAMPLES.DESCRIPTION,
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when the response from ODS does not have status as SUCCESS', () => {
+    it('should throw an error', async () => {
+      // Arrange
+
+      const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findDeal(DEALS.EXAMPLES.ID);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a deal');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the response from ODS has total_result_count as 0', () => {
+    it('should throw an error', async () => {
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findDeal(DEALS.EXAMPLES.ID);
+
+      await expect(promise).rejects.toBeInstanceOf(NotFoundException);
+
+      const expected = new Error('No deal found');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the method goes into the catch handler', () => {
+    it('should throw an error', async () => {
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.findDeal(DEALS.EXAMPLES.ID);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a deal');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when callOdsStoredProcedure throws an error', () => {
+    it('should throw an error', async () => {
+      jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
+
+      // Act & Assert
+      const promise = service.findDeal(DEALS.EXAMPLES.ID);
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error finding a deal');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+});

--- a/src/modules/ods/ods.service-getBusinessCentres.test.ts
+++ b/src/modules/ods/ods.service-getBusinessCentres.test.ts
@@ -1,0 +1,141 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { BUSINESS_CENTRE } from '@ukef/constants';
+import { mapBusinessCentres } from '@ukef/helpers';
+import { PinoLogger } from 'nestjs-pino';
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { ODS_ENTITIES, OdsStoredProcedureInput } from './dto/ods-payloads.dto';
+import { OdsService } from './ods.service';
+
+describe('OdsService - getBusinessCentres', () => {
+  let service: OdsService;
+  let mockQueryRunner: jest.Mocked<QueryRunner>;
+  let mockDataSource: jest.Mocked<DataSource>;
+  const mockLogger = new PinoLogger({});
+
+  beforeEach(() => {
+    mockQueryRunner = {
+      query: jest.fn(),
+      release: jest.fn(),
+    } as unknown as jest.Mocked<QueryRunner>;
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as unknown as jest.Mocked<DataSource>;
+
+    service = new OdsService(mockDataSource, mockLogger);
+  });
+
+  const mockStoredProcedureOutput = `{
+    "message": "SUCCESS",
+    "status": "SUCCESS",
+    "total_result_count": 2,
+    "results": [
+      {
+        "business_centre_code": "${BUSINESS_CENTRE.EXAMPLES.CODE}",
+        "business_centre_name": "${BUSINESS_CENTRE.EXAMPLES.NAME}"
+      },
+      {
+        "business_centre_code": "${BUSINESS_CENTRE.EXAMPLES.CODE}",
+        "business_centre_name": "${BUSINESS_CENTRE.EXAMPLES.NAME}"
+      }
+    ]
+  }`;
+
+  beforeEach(() => {
+    jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+  });
+
+  it('should call service.callOdsStoredProcedure', async () => {
+    // Act
+    await service.getBusinessCentres();
+
+    // Assert
+    const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
+      entityToQuery: ODS_ENTITIES.BUSINESS_CENTRE,
+    });
+
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
+    expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
+  });
+
+  it('should return mapped business centres', async () => {
+    // Act
+    const result = await service.getBusinessCentres();
+
+    // Assert
+    const expected = mapBusinessCentres(JSON.parse(mockStoredProcedureOutput).results);
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when the response from ODS does not have status as SUCCESS', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.getBusinessCentres();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error getting business centres');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the response from ODS has total_result_count as 0', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      const expected = new Error('Error getting business centres');
+
+      // Act & Assert
+      const promise = service.getBusinessCentres();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when the method goes into the catch handler', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
+
+      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
+
+      // Act & Assert
+      const promise = service.getBusinessCentres();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error getting business centres');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+
+  describe('when callOdsStoredProcedure throws an error', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
+
+      // Act & Assert
+      const promise = service.getBusinessCentres();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      const expected = new Error('Error getting business centres');
+
+      await expect(promise).rejects.toThrow(expected);
+    });
+  });
+});

--- a/src/modules/ods/ods.service.test.ts
+++ b/src/modules/ods/ods.service.test.ts
@@ -1,6 +1,4 @@
-import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
-import { BUSINESS_CENTRE, CUSTOMERS, DEALS } from '@ukef/constants';
-import { mapBusinessCentres } from '@ukef/helpers';
+import { CUSTOMERS } from '@ukef/constants';
 import { PinoLogger } from 'nestjs-pino';
 import { DataSource, QueryRunner } from 'typeorm';
 
@@ -26,340 +24,21 @@ describe('OdsService', () => {
     service = new OdsService(mockDataSource, mockLogger);
   });
 
-  describe('findCustomer', () => {
-    const mockCustomer = { urn: CUSTOMERS.EXAMPLES.PARTYURN, name: 'Test Customer' };
-
-    const mockStoredProcedureOutput = `{
-      "query_request_id": "Test ID",
-      "message": "SUCCESS",
-      "status": "SUCCESS",
-      "total_result_count": 1,
-      "results": [
-        {
-          "customer_party_unique_reference_number": "${mockCustomer.urn}",
-          "customer_name": "${mockCustomer.name}",
-          "customer_companies_house_number": "12345678",
-          "customer_addresses": [
-            {
-              "customer_address_type": "Registered",
-              "customer_address_street": "Test Street",
-              "customer_address_postcode": "AA1 1BB",
-              "customer_address_country": "United Kingdom",
-              "customer_address_city": "Test City"
-            }
-          ]
-        }
-      ]
-    }`;
-
-    beforeEach(() => {
-      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-    });
-
-    it('should call service.callOdsStoredProcedure', async () => {
-      await service.findCustomer(mockCustomer.urn);
-
-      const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
-        entityToQuery: ODS_ENTITIES.CUSTOMER,
-        queryPageSize: 1,
-        queryParameters: { customer_party_unique_reference_number: mockCustomer.urn },
-      });
-
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
-    });
-
-    it('should return a customer', async () => {
-      const result = await service.findCustomer(mockCustomer.urn);
-
-      expect(result).toEqual(mockCustomer);
-    });
-
-    describe('when the response from ODS does not have status as SUCCESS', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error finding a customer');
-
-        const promise = service.findCustomer(mockCustomer.urn);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the response from ODS has total_result_count as 0', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('No customer found');
-
-        const promise = service.findCustomer(mockCustomer.urn);
-
-        await expect(promise).rejects.toBeInstanceOf(NotFoundException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the method goes into the catch handler', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error finding a customer');
-
-        const promise = service.findCustomer(mockCustomer.urn);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when callOdsStoredProcedure throws an error', () => {
-      it('should throw an error', async () => {
-        jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
-
-        const expected = new Error('Error finding a customer');
-
-        const promise = service.findCustomer(mockCustomer.urn);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-  });
-
-  describe('findDeal', () => {
-    const mockStoredProcedureOutput = `{
-      "query_request_id": "Test ID",
-      "message": "SUCCESS",
-      "status": "SUCCESS",
-      "total_result_count": 1,
-      "results": [
-        {
-          "deal_code": "${DEALS.EXAMPLES.ID}",
-          "deal_name": "${DEALS.EXAMPLES.NAME}",
-          "deal_type_description": "${DEALS.EXAMPLES.DESCRIPTION}"
-        }
-      ]
-    }`;
-
-    beforeEach(() => {
-      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-    });
-
-    it('should call service.callOdsStoredProcedure', async () => {
-      const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
-        entityToQuery: ODS_ENTITIES.DEAL,
-        queryPageSize: 1,
-        queryParameters: { deal_code: DEALS.EXAMPLES.ID },
-      });
-
-      await service.findDeal(DEALS.EXAMPLES.ID);
-
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
-    });
-
-    it('should return a deal', async () => {
-      const result = await service.findDeal(DEALS.EXAMPLES.ID);
-
-      const expected = {
-        dealId: DEALS.EXAMPLES.ID,
-        name: DEALS.EXAMPLES.NAME,
-        description: DEALS.EXAMPLES.DESCRIPTION,
-      };
-
-      expect(result).toEqual(expected);
-    });
-
-    describe('when the response from ODS does not have status as SUCCESS', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error finding a deal');
-
-        const promise = service.findDeal(DEALS.EXAMPLES.ID);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the response from ODS has total_result_count as 0', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('No deal found');
-
-        const promise = service.findDeal(DEALS.EXAMPLES.ID);
-
-        await expect(promise).rejects.toBeInstanceOf(NotFoundException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the method goes into the catch handler', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error finding a deal');
-
-        const promise = service.findDeal(DEALS.EXAMPLES.ID);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when callOdsStoredProcedure throws an error', () => {
-      it('should throw an error', async () => {
-        jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
-
-        const expected = new Error('Error finding a deal');
-
-        const promise = service.findDeal(DEALS.EXAMPLES.ID);
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-  });
-
-  describe('getBusinessCentres', () => {
-    const mockStoredProcedureOutput = `{
-      "message": "SUCCESS",
-      "status": "SUCCESS",
-      "total_result_count": 2,
-      "results": [
-        {
-          "business_centre_code": "${BUSINESS_CENTRE.EXAMPLES.CODE}",
-          "business_centre_name": "${BUSINESS_CENTRE.EXAMPLES.NAME}"
-        },
-        {
-          "business_centre_code": "${BUSINESS_CENTRE.EXAMPLES.CODE}",
-          "business_centre_name": "${BUSINESS_CENTRE.EXAMPLES.NAME}"
-        }
-      ]
-    }`;
-
-    beforeEach(() => {
-      jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-    });
-
-    it('should call service.callOdsStoredProcedure', async () => {
-      const expectedStoredProcedureInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
-        entityToQuery: ODS_ENTITIES.BUSINESS_CENTRE,
-      });
-
-      await service.getBusinessCentres();
-
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledTimes(1);
-      expect(service.callOdsStoredProcedure).toHaveBeenCalledWith(expectedStoredProcedureInput);
-    });
-
-    it('should return mapped business centres', async () => {
-      const result = await service.getBusinessCentres();
-
-      const expected = mapBusinessCentres(JSON.parse(mockStoredProcedureOutput).results);
-
-      expect(result).toEqual(expected);
-    });
-
-    describe('when the response from ODS does not have status as SUCCESS', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "NOT SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error getting business centres');
-
-        const promise = service.getBusinessCentres();
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the response from ODS has total_result_count as 0', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS", "total_result_count": 0 }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error getting business centres');
-
-        const promise = service.getBusinessCentres();
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when the method goes into the catch handler', () => {
-      it('should throw an error', async () => {
-        const mockStoredProcedureOutput = `{ "status": "SUCCESS" }`;
-
-        jest.spyOn(service, 'callOdsStoredProcedure').mockResolvedValue(mockStoredProcedureOutput);
-
-        const expected = new Error('Error getting business centres');
-
-        const promise = service.getBusinessCentres();
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-
-    describe('when callOdsStoredProcedure throws an error', () => {
-      it('should throw an error', async () => {
-        jest.spyOn(service, 'callOdsStoredProcedure').mockRejectedValue('Mock ODS error');
-
-        const expected = new Error('Error getting business centres');
-
-        const promise = service.getBusinessCentres();
-
-        await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
-
-        await expect(promise).rejects.toThrow(expected);
-      });
-    });
-  });
-
   describe('createOdsStoredProcedureInput', () => {
     it('should map the inputs to the stored procedure input format', () => {
+      // Arrange
       const exampleCustomerQueryParameters = {
         customer_party_unique_reference_number: CUSTOMERS.EXAMPLES.PARTYURN,
       };
 
+      // Act
       const result = service.createOdsStoredProcedureInput({
         entityToQuery: ODS_ENTITIES.CUSTOMER,
         queryPageSize: 100,
         queryParameters: exampleCustomerQueryParameters,
       });
 
+      // Assert
       const expected: OdsStoredProcedureInput = {
         query_method: 'get',
         query_object: ODS_ENTITIES.CUSTOMER,
@@ -374,6 +53,7 @@ describe('OdsService', () => {
 
   describe('callOdsStoredProcedure', () => {
     it('should call the stored procedure with the query runner', async () => {
+      // Arrange
       const mockInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
         entityToQuery: ODS_ENTITIES.CUSTOMER,
         queryPageSize: 100,
@@ -386,8 +66,10 @@ describe('OdsService', () => {
 
       mockQueryRunner.query.mockResolvedValue(mockResult);
 
+      // Act
       const result = await service.callOdsStoredProcedure(mockInput);
 
+      // Assert
       expect(mockDataSource.createQueryRunner).toHaveBeenCalledTimes(1);
 
       expect(mockQueryRunner.query).toHaveBeenCalledWith(
@@ -403,6 +85,7 @@ describe('OdsService', () => {
     });
 
     it('throws an error if calling the stored procedure fails', async () => {
+      // Arrange
       const mockInput: OdsStoredProcedureInput = service.createOdsStoredProcedureInput({
         entityToQuery: ODS_ENTITIES.CUSTOMER,
         queryParameters: { customer_party_unique_reference_number: CUSTOMERS.EXAMPLES.PARTYURN },
@@ -410,9 +93,10 @@ describe('OdsService', () => {
 
       mockQueryRunner.query.mockRejectedValue(new Error('Test Error'));
 
-      const resultPromise = service.callOdsStoredProcedure(mockInput);
+      // Act & Assert
+      const promise = service.callOdsStoredProcedure(mockInput);
 
-      await expect(resultPromise).rejects.toThrow('Test Error');
+      await expect(promise).rejects.toThrow('Test Error');
 
       expect(mockDataSource.createQueryRunner).toHaveBeenCalledTimes(1);
       expect(mockQueryRunner.release).toHaveBeenCalledTimes(1);

--- a/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
+++ b/test/docs/__snapshots__/get-docs-yaml.api-test.ts.snap
@@ -487,6 +487,22 @@ paths:
       summary: Get all markets (aka countries)
       tags:
         - markets
+  /api/v1/ods/business-centres:
+    get:
+      operationId: OdsController_getBusinessCentres_v1
+      parameters: []
+      responses:
+        '200':
+          description: Business centres
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetOdsBusinessCentreMappedResponse'
+        '500':
+          description: Internal server error.
+      summary: Get business centres from ODS
+      tags:
+        - ods
   /api/v1/ods/customers/{urn}:
     get:
       operationId: OdsController_findCustomer_v1
@@ -1216,6 +1232,20 @@ components:
         - shortTermCoverAvailabilityDesc
         - NBIIssue
         - active
+    GetOdsBusinessCentreMappedResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Business centre code
+          example: DbB
+        name:
+          type: string
+          description: Business centre name
+          example: Dubai bank holidays
+      required:
+        - code
+        - name
     GetOdsCustomerResponse:
       type: object
       properties:

--- a/test/ods/ods.business-centres.api-test.ts
+++ b/test/ods/ods.business-centres.api-test.ts
@@ -1,0 +1,35 @@
+import { HttpStatus } from '@nestjs/common';
+import { Api } from '@ukef-test/support/api';
+
+describe('/ods/business-centres', () => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  describe('/', () => {
+    it(`should return ${HttpStatus.OK} with mapped business centres`, async () => {
+      // Act
+      const { status, body } = await api.get('/api/v1/ods/business-centres');
+
+      // Assert
+      expect(status).toBe(HttpStatus.OK);
+
+      const expected = expect.arrayContaining([
+        expect.objectContaining({
+          code: expect.any(String),
+          name: expect.any(String),
+        }),
+      ]);
+
+      expect(body).toEqual(expected);
+    });
+
+    // TODO: APIM-613 - create a mock request to mimic receiving a 500 error from ODS.
+  });
+});

--- a/test/ods/ods.customers.api-test.ts
+++ b/test/ods/ods.customers.api-test.ts
@@ -4,11 +4,6 @@ import { Api } from '@ukef-test/support/api';
 describe('/ods/customers', () => {
   let api: Api;
 
-  const expectedResult = expect.objectContaining({
-    name: expect.any(String),
-    urn: expect.any(String),
-  });
-
   beforeAll(async () => {
     api = await Api.create();
   });
@@ -25,7 +20,12 @@ describe('/ods/customers', () => {
       // Assert
       expect(status).toBe(HttpStatus.OK);
 
-      expect(body).toEqual(expectedResult);
+      const expected = expect.objectContaining({
+        name: expect.any(String),
+        urn: expect.any(String),
+      });
+
+      expect(body).toEqual(expected);
     });
 
     it(`should return ${HttpStatus.NOT_FOUND} when the URN has a valid format, but does not match an existing customer`, async () => {

--- a/test/ods/ods.deal.api-test.ts
+++ b/test/ods/ods.deal.api-test.ts
@@ -4,11 +4,6 @@ import { Api } from '@ukef-test/support/api';
 describe('/ods/deal', () => {
   let api: Api;
 
-  const expectedResult = expect.objectContaining({
-    dealId: expect.any(String),
-    name: expect.any(String),
-  });
-
   beforeAll(async () => {
     api = await Api.create();
   });
@@ -25,7 +20,12 @@ describe('/ods/deal', () => {
       // Assert
       expect(status).toBe(HttpStatus.OK);
 
-      expect(body).toEqual(expectedResult);
+      const expected = expect.objectContaining({
+        dealId: expect.any(String),
+        name: expect.any(String),
+      });
+
+      expect(body).toEqual(expected);
     });
 
     it(`should return ${HttpStatus.NOT_FOUND} when the deal ID is a valid format, but does not match an existing deal`, async () => {


### PR DESCRIPTION
# Introduction :pencil2:

This PR introduces a new endpoint so that business centres can be obtained from ODS.

## Resolution :heavy_check_mark:

- Create new constant.
- Create new helper function, `mapBusinessCentres`.
- Create/update DTOs.
- Make ODS stored procedure `query_page_size` param optional.
- Update `createOdsStoredProcedureInput` to have object structured params.
- Create new `/business-centres` endpoint/controller.
- Create new `getBusinessCentres` ODS service method.
- Add/update tests.


## Miscellaneous :heavy_plus_sign:

- Various minor readability improvements.
- Align helper unit test naming conventions.
- Add Arrange/Act/Assert comments to various tests.
- Split up ODS service unit tests.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ### Request
   GET /api/v1/ods/business-centres

  ### Response
  ```json
    [
      {
        "code": "AcB",
        "name": "Accra bank holidays"
      },
      {
        "code": "AqB",
        "name": "Addis Ababa bank holidays"
      }
    ]
  ```
</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
