### PR TITLE
fix(GIFT-13526): business centre mapping

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './convert-string-to-buffer';
+export * from './map-business-centre';
 export * from './map-business-centre-non-working-days';
 export * from './map-business-centres';
 export * from './regex.helper';

--- a/src/helpers/map-business-centre.ts
+++ b/src/helpers/map-business-centre.ts
@@ -1,0 +1,13 @@
+import { DomBusinessCentre } from '@ukef/constants';
+
+import { GetDomBusinessCentreResponse } from '../modules/dom/dto';
+
+/**
+ * Map a DOM business centre data into a more suitable format for consumers.
+ * @param {DomBusinessCentre} DOM Business centres
+ * @returns {GetDomBusinessCentreResponse} Mapped business centre
+ */
+export const mapBusinessCentre = (centre: DomBusinessCentre): GetDomBusinessCentreResponse => ({
+  code: centre.CODE,
+  name: centre.NAME,
+});

--- a/src/helpers/map-business-centres.test.ts
+++ b/src/helpers/map-business-centres.test.ts
@@ -1,5 +1,6 @@
 import { DOM_BUSINESS_CENTRES } from '@ukef/constants';
 
+import { mapBusinessCentre } from './map-business-centre';
 import { mapBusinessCentres } from './map-business-centres';
 
 describe('mapBusinessCentres', () => {
@@ -11,10 +12,7 @@ describe('mapBusinessCentres', () => {
     const result = mapBusinessCentres(businessCentres);
 
     // Assert
-    const expected = businessCentres.map((centre) => ({
-      code: centre.CODE,
-      name: centre.NAME,
-    }));
+    const expected = businessCentres.map((centre) => mapBusinessCentre(centre));
 
     expect(result).toEqual(expected);
   });

--- a/src/helpers/map-business-centres.ts
+++ b/src/helpers/map-business-centres.ts
@@ -1,6 +1,7 @@
 import { DomBusinessCentre } from '@ukef/constants';
 
 import { GetDomBusinessCentreResponse } from '../modules/dom/dto';
+import { mapBusinessCentre } from './map-business-centre';
 
 /**
  * Map DOM business centres data from constants, into a more suitable format for consumers.
@@ -8,7 +9,4 @@ import { GetDomBusinessCentreResponse } from '../modules/dom/dto';
  * @returns {GetDomBusinessCentreResponse[]} Mapped business centres
  */
 export const mapBusinessCentres = (centres: DomBusinessCentre[]): GetDomBusinessCentreResponse[] =>
-  centres.map((centre: DomBusinessCentre) => ({
-    code: centre.CODE,
-    name: centre.NAME,
-  }));
+  centres.map((centre: DomBusinessCentre) => mapBusinessCentre(centre));

--- a/src/modules/dom/dom.service.test.ts
+++ b/src/modules/dom/dom.service.test.ts
@@ -1,6 +1,6 @@
 import { NotFoundException } from '@nestjs/common';
 import { DOM_BUSINESS_CENTRES, EXAMPLES } from '@ukef/constants';
-import { mapBusinessCentres } from '@ukef/helpers';
+import { mapBusinessCentre, mapBusinessCentres } from '@ukef/helpers';
 import { PinoLogger } from 'nestjs-pino';
 import { DataSource, QueryRunner } from 'typeorm';
 
@@ -29,7 +29,7 @@ describe('DomService', () => {
 
   describe('findBusinessCentre', () => {
     describe('when a business centre is found', () => {
-      it('should return the business centre', () => {
+      it('should return a mapped business centre', () => {
         // Arrange
         const mockCentreCode = DOM_BUSINESS_CENTRES.CM_YAO.CODE;
 
@@ -37,7 +37,7 @@ describe('DomService', () => {
         const response = service.findBusinessCentre(mockCentreCode);
 
         // Assert
-        const expected = DOM_BUSINESS_CENTRES.CM_YAO;
+        const expected = mapBusinessCentre(DOM_BUSINESS_CENTRES.CM_YAO);
 
         expect(response).toEqual(expected);
       });

--- a/src/modules/dom/dom.service.ts
+++ b/src/modules/dom/dom.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { DOM_BUSINESS_CENTRES, EXAMPLES } from '@ukef/constants';
-import { mapBusinessCentres } from '@ukef/helpers';
+import { mapBusinessCentre, mapBusinessCentres } from '@ukef/helpers';
 import { PinoLogger } from 'nestjs-pino';
 
 import { OdsService } from '../ods/ods.service';
@@ -30,7 +30,7 @@ export class DomService {
     const centre = DOM_BUSINESS_CENTRES[`${centreCode}`];
 
     if (centre) {
-      return centre;
+      return mapBusinessCentre(centre);
     }
 
     throw new NotFoundException(`No business centre found ${centreCode}`);

--- a/test/dom/dom.business-centres.api-test.ts
+++ b/test/dom/dom.business-centres.api-test.ts
@@ -32,7 +32,10 @@ describe('/dom - business centres', () => {
         // Assert
         expect(status).toBe(HttpStatus.OK);
 
-        const expected = DOM_BUSINESS_CENTRES.AE_DXB;
+        const expected = {
+          code: DOM_BUSINESS_CENTRES.AE_DXB.CODE,
+          name: DOM_BUSINESS_CENTRES.AE_DXB.NAME,
+        };
 
         expect(body).toEqual(expected);
       });


### PR DESCRIPTION
# Introduction :pencil2:

The "Get a business centre" endpoint was returning uppercase `code` and `name` fields.

## Resolution :heavy_check_mark:

- Create `mapBusinessCentre` helper.
- Update `mapBusinessCentres` helper.
- Update DOM service.
- Update API test.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   {
     "code": "GH_ACC",
     "name": "Accra"
   }
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
