### PR TITLE
fix(deployment): node version

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,6 +26,7 @@ on:
       - dev
       - staging
       - production
+      - fix/deployment
 
     paths:
       - 'src/**'
@@ -47,7 +48,7 @@ jobs:
   # 1. Setup deployment variables
   setup:
     name: Setup 🔧
-    runs-on: [self-hosted, APIM, deployment]
+    runs-on: [ubuntu-latest]
     outputs:
       product: ${{ env.PRODUCT }}
       environment: ${{ env.ENVIRONMENT }}
@@ -68,7 +69,7 @@ jobs:
       NAME: mdm
       NAME_UPPERCASE: MDM
       ENVIRONMENT: ${{ needs.setup.outputs.environment }}
-    runs-on: [self-hosted, APIM, deployment]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Repository 🗃️
         uses: actions/checkout@v5


### PR DESCRIPTION
# Introduction :pencil2:

The current deployment is failing on private runner due to following error.

```sh
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node24' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.')
```

## Resolution :heavy_check_mark:

* Changed the deployment to public runner for test.

## Miscellaneous :heavy_plus_sign:

* Dependencies updates