### PR TITLE
fix(releaseNotes): update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Create
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
# Introduction :pencil2:

Release note PRs are not being generated.

## Resolution :heavy_check_mark:

- Replace in `RELEASE_TOKEN` with `GITHUB_TOKEN` in `publish.yml`.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
