### PR TITLE
fix(APIM-624): premium schedules endpoint

### DIFF
--- a/src/modules/premium-schedules/premium-schedules.controller.ts
+++ b/src/modules/premium-schedules/premium-schedules.controller.ts
@@ -8,11 +8,11 @@ import { PremiumScheduleEntity } from './entities/premium-schedule.entity';
 import { PremiumSchedulesService } from './premium-schedules.service';
 
 @ApiTags('premium-schedules')
-@Controller('premium-schedules')
+@Controller('premium')
 export class PremiumSchedulesController {
   constructor(private readonly premiumSchedulesService: PremiumSchedulesService) {}
 
-  @Post('premium/schedule')
+  @Post('/schedule')
   @ApiOperation({ summary: 'Create a premium schedule sequence (AKA Income exposure)' })
   @ApiBody({ type: [CreatePremiumScheduleDto] })
   create(
@@ -26,7 +26,7 @@ export class PremiumSchedulesController {
     return this.premiumSchedulesService.create(res, createPremiumSchedule[0]);
   }
 
-  @Get('premium/segments/:facilityId')
+  @Get('/segments/:facilityId')
   @ApiOperation({ summary: 'Return previously generated premium schedule sequence/segments (AKA Income exposures)' })
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
# Introduction :pencil2:

The premium schedules endpoint/URL was accidentally change in [this PR](https://github.com/UK-Export-Finance/mdm-api/pull/1713/changes#diff-d71569798bfca441f2bee68c5f8998c2121a46395e5f450466612e19c39f6e10)

from
 
POST `/premium/schedule`
GET `/premium/segments/:facilityId`
 
to 
POST `/premium-schedules/premium/schedule`
GET `/premium-schedules/premium/segments/:facilityId`

This PR ensures that the original URLs are in place.

## Resolution :heavy_check_mark:

- Update premium schedule controller.

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

  ```json
   
  ```

</details>

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  Add screenshots here.
</details>
