### PR TITLE
feat(GIFT-25255): add obligation config

### DIFF
--- a/src/constants/examples/examples.constant.ts
+++ b/src/constants/examples/examples.constant.ts
@@ -251,6 +251,10 @@ export const EXAMPLES = {
             creation: PRODUCT_CONFIG_REQUIREMENT.REQUIRED,
             inLife: PRODUCT_CONFIG_REQUIREMENT.OPTIONAL,
           },
+          obligations: {
+            creation: PRODUCT_CONFIG_REQUIREMENT.REQUIRED,
+            inLife: PRODUCT_CONFIG_REQUIREMENT.OPTIONAL,
+          },
           reinsurance: {
             creation: PRODUCT_CONFIG_REQUIREMENT.OPTIONAL,
             inLife: PRODUCT_CONFIG_REQUIREMENT.OPTIONAL,

--- a/src/helper-modules/dom/dom-product-config.json
+++ b/src/helper-modules/dom/dom-product-config.json
@@ -10,6 +10,10 @@
         "creation": "OPTIONAL",
         "inLife": "OPTIONAL"
       },
+      "obligations": {
+        "creation": "REQUIRED",
+        "inLife": "OPTIONAL"
+      },
       "reinsurance": {
         "creation": "OPTIONAL",
         "inLife": "OPTIONAL"
@@ -26,7 +30,11 @@
       "fees": {
         "creation": "OPTIONAL",
         "inLife": "OPTIONAL"
-      },
+        },
+        "obligations": {
+          "creation": "REQUIRED",
+          "inLife": "OPTIONAL"
+        },
       "reinsurance": {
         "creation": "OPTIONAL",
         "inLife": "OPTIONAL"
@@ -42,6 +50,10 @@
       "expiryDate": "REQUIRED",
       "fees": {
         "creation": "NOT_APPLICABLE",
+        "inLife": "OPTIONAL"
+      },
+      "obligations": {
+        "creation": "REQUIRED",
         "inLife": "OPTIONAL"
       },
       "reinsurance": {
@@ -61,6 +73,10 @@
         "creation": "NOT_APPLICABLE",
         "inLife": "OPTIONAL"
       },
+      "obligations": {
+        "creation": "REQUIRED",
+        "inLife": "OPTIONAL"
+      },
       "reinsurance": {
         "creation": "NOT_APPLICABLE",
         "inLife": "NOT_APPLICABLE"
@@ -75,6 +91,10 @@
       "availabilityEndDate": "REQUIRED",
       "expiryDate": "REQUIRED",
       "fees": {
+        "creation": "OPTIONAL",
+        "inLife": "OPTIONAL"
+      },
+      "obligations": {
         "creation": "OPTIONAL",
         "inLife": "OPTIONAL"
       },

--- a/src/helpers/map-product-config.test.ts
+++ b/src/helpers/map-product-config.test.ts
@@ -85,6 +85,8 @@ describe('mapProductConfig', () => {
       // PRT001 values from dom-product-config.json
       expect(result.configuration.fees.creation).toEqual(OPTIONAL);
       expect(result.configuration.fees.inLife).toEqual(OPTIONAL);
+      expect(result.configuration.obligations.creation).toEqual(REQUIRED);
+      expect(result.configuration.obligations.inLife).toEqual(OPTIONAL);
       expect(result.configuration.reinsurance.creation).toEqual(OPTIONAL);
       expect(result.configuration.reinsurance.inLife).toEqual(OPTIONAL);
     });
@@ -114,13 +116,15 @@ describe('mapProductConfig', () => {
       expect(result.configuration.bankRate).toEqual(NOT_APPLICABLE);
     });
 
-    it('should default configuration.fees to NOT_APPLICABLE', () => {
+    it('should default entity options to OPTIONAL', () => {
       const result = mapProductConfig(mockOdsProductConfigUnknown);
 
-      expect(result.configuration.fees.creation).toEqual(NOT_APPLICABLE);
-      expect(result.configuration.fees.inLife).toEqual(NOT_APPLICABLE);
-      expect(result.configuration.reinsurance.creation).toEqual(NOT_APPLICABLE);
-      expect(result.configuration.reinsurance.inLife).toEqual(NOT_APPLICABLE);
+      expect(result.configuration.fees.creation).toEqual(OPTIONAL);
+      expect(result.configuration.fees.inLife).toEqual(OPTIONAL);
+      expect(result.configuration.obligations.creation).toEqual(OPTIONAL);
+      expect(result.configuration.obligations.inLife).toEqual(OPTIONAL);
+      expect(result.configuration.reinsurance.creation).toEqual(OPTIONAL);
+      expect(result.configuration.reinsurance.inLife).toEqual(OPTIONAL);
     });
   });
 

--- a/src/helpers/map-product-config.ts
+++ b/src/helpers/map-product-config.ts
@@ -3,6 +3,7 @@ import { GetDomProductConfigResponse } from '@ukef/modules/dom/dto';
 import { GetProductConfigOdsResponse } from '@ukef/modules/ods/dto';
 
 const NOT_APPLICABLE = 'NOT_APPLICABLE';
+const OPTIONAL = 'OPTIONAL';
 
 /**
  * Maps an ODS product config response to a DOM product config response.
@@ -48,12 +49,16 @@ export const mapProductConfig = (odsProductConfig: GetProductConfigOdsResponse):
       bankRate: NOT_APPLICABLE,
       repaymentType: odsProductConfig.configuration.repaymentType,
       fees: {
-        creation: conf?.fees?.creation ?? NOT_APPLICABLE,
-        inLife: conf?.fees?.inLife ?? NOT_APPLICABLE,
+        creation: conf?.fees?.creation ?? OPTIONAL,
+        inLife: conf?.fees?.inLife ?? OPTIONAL,
+      },
+      obligations: {
+        creation: conf?.obligations?.creation ?? OPTIONAL,
+        inLife: conf?.obligations?.inLife ?? OPTIONAL,
       },
       reinsurance: {
-        creation: conf?.reinsurance?.creation ?? NOT_APPLICABLE,
-        inLife: conf?.reinsurance?.inLife ?? NOT_APPLICABLE,
+        creation: conf?.reinsurance?.creation ?? OPTIONAL,
+        inLife: conf?.reinsurance?.inLife ?? OPTIONAL,
       },
       leadDays: odsProductConfig.configuration.leadDays,
     },

--- a/src/modules/dom/dto/get-dom-product-config-config-obligations.dto.ts
+++ b/src/modules/dom/dto/get-dom-product-config-config-obligations.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EXAMPLES } from '@ukef/constants';
+
+export class GetDomProductConfigConfigObligations {
+  @ApiProperty({
+    description: 'If obligations can be added to the product at creation time',
+    example: EXAMPLES.DOM.PRODUCT_CONFIG.BIP.configuration.obligations.creation,
+  })
+  readonly creation: string;
+
+  @ApiProperty({
+    description: 'If obligations can be added to the product during its lifecycle',
+    example: EXAMPLES.DOM.PRODUCT_CONFIG.BIP.configuration.obligations.inLife,
+  })
+  readonly inLife: string;
+}

--- a/src/modules/dom/dto/get-dom-product-config-config.dto.ts
+++ b/src/modules/dom/dto/get-dom-product-config-config.dto.ts
@@ -3,6 +3,7 @@ import { EXAMPLES } from '@ukef/constants';
 
 import { GetDomProductConfigConfigFees } from './get-dom-product-config-config-fees.dto';
 import { GetDomProductConfigConfigLeadDays } from './get-dom-product-config-config-lead-days.dto';
+import { GetDomProductConfigConfigObligations } from './get-dom-product-config-config-obligations.dto';
 import { GetDomProductConfigConfigReinsurance } from './get-dom-product-config-config-reinsurance.dto';
 
 export class GetDomProductConfigConfig {
@@ -131,6 +132,12 @@ export class GetDomProductConfigConfig {
     example: EXAMPLES.DOM.PRODUCT_CONFIG.BIP.configuration.fees,
   })
   readonly fees: GetDomProductConfigConfigFees;
+
+  @ApiProperty({
+    description: "The product's 'obligations'",
+    example: EXAMPLES.DOM.PRODUCT_CONFIG.BIP.configuration.obligations,
+  })
+  readonly obligations: GetDomProductConfigConfigObligations;
 
   @ApiProperty({
     description: "The product's 'reinsurance'",

--- a/test/dom/dom-product-configurations.api-test.ts
+++ b/test/dom/dom-product-configurations.api-test.ts
@@ -40,6 +40,10 @@ describe('/dom - product-configuration', () => {
           creation: expect.any(String),
           inLife: expect.any(String),
         }),
+        obligations: expect.objectContaining({
+          creation: expect.any(String),
+          inLife: expect.any(String),
+        }),
       }),
       additionalRates: expect.any(Array),
       accrualSchedules: expect.any(Array),


### PR DESCRIPTION
# Introduction :pencil2:

Add a section to GIFT product config for obligations.


## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```bash
curl -X 'GET' \
  'http://localhost:5010/api/v2/dom/product-configurations' \
  -H 'accept: application/json' \
  -H 'x-api-key: test'
```

  ```json
   [
  {
    "productType": "PRT001",
    "name": "Bond Insurance Policy",
    "shortName": "BIP",
    "configuration": {
      "commitmentDate": "NOT_APPLICABLE",
      "issuedDate": "NOT_APPLICABLE",
      "effectiveDate": "REQUIRED",
      "availabilityEndDate": "NOT_APPLICABLE",
      "expiryDate": "REQUIRED",
      "creditType": "TERM",
      "instrumentType": "Insurance",
      "participations": "NOT_APPLICABLE",
      "scheduledRepayments": "NOT_APPLICABLE",
      "nonCashObligations": "NOT_APPLICABLE",
      "cashObligations": "NOT_APPLICABLE",
      "accrualSchedule": "NOT_APPLICABLE",
      "pimOwner": "NOT_APPLICABLE",
      "riskRating": "NOT_APPLICABLE",
      "preCreditPeriod": "NOT_APPLICABLE",
      "creditPeriod": "NOT_APPLICABLE",
      "lossGivenDefault": "NOT_APPLICABLE",
      "provisionRate": "NOT_APPLICABLE",
      "forecastYear": "NOT_APPLICABLE",
      "bankRate": "NOT_APPLICABLE",
      "repaymentType": "Bullet",
      "fees": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "obligations": {
        "creation": "REQUIRED",
        "inLife": "OPTIONAL"
      },
      "reinsurance": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "leadDays": {
        "repayments": 5,
        "interestAccruals": 5,
        "accruingFees": 1
      }
    },
    "additionalRates": [],
    "accrualSchedules": [],
    "baseRates": [],
    "counterpartyRoleTypes": [
      "CRT001",
      "CRT004",
      "CRT005",
      "CRT013",
      "CRT042"
    ],
    "facilityCategoryTypes": [
      "FCT001",
      "FCT002",
      "FCT003"
    ],
    "feeTypes": [
      "BEX",
      "PLA"
    ],
    "obligationSubtypes": [
      "OST001",
      "OST002",
      "OST003",
      "OST004",
      "OST005",
      "OST006",
      "OST008"
    ],
    "account": [
      "2",
      "3",
      "7"
    ],
    "productActive": true
  },
  {
    "productType": "PRT002",
    "name": "Export Insurance Policy",
    "shortName": "EXIP",
    "configuration": {
      "commitmentDate": "NOT_APPLICABLE",
      "issuedDate": "NOT_APPLICABLE",
      "effectiveDate": "REQUIRED",
      "availabilityEndDate": "NOT_APPLICABLE",
      "expiryDate": "REQUIRED",
      "creditType": "TERM",
      "instrumentType": "Insurance",
      "participations": "NOT_APPLICABLE",
      "scheduledRepayments": "NOT_APPLICABLE",
      "nonCashObligations": "NOT_APPLICABLE",
      "cashObligations": "NOT_APPLICABLE",
      "accrualSchedule": "NOT_APPLICABLE",
      "pimOwner": "NOT_APPLICABLE",
      "riskRating": "NOT_APPLICABLE",
      "preCreditPeriod": "NOT_APPLICABLE",
      "creditPeriod": "NOT_APPLICABLE",
      "lossGivenDefault": "NOT_APPLICABLE",
      "provisionRate": "NOT_APPLICABLE",
      "forecastYear": "NOT_APPLICABLE",
      "bankRate": "NOT_APPLICABLE",
      "repaymentType": "Bullet",
      "fees": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "obligations": {
        "creation": "REQUIRED",
        "inLife": "OPTIONAL"
      },
      "reinsurance": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "leadDays": {
        "repayments": 5,
        "interestAccruals": 5,
        "accruingFees": 1
      }
    },
    "additionalRates": [],
    "accrualSchedules": [],
    "baseRates": [],
    "counterpartyRoleTypes": [
      "CRT001",
      "CRT002",
      "CRT013",
      "CRT018",
      "CRT036",
      "CRT042"
    ],
    "facilityCategoryTypes": [],
    "feeTypes": [
      "BEX",
      "PLA"
    ],
    "obligationSubtypes": [
      "OST009",
      "OST010",
      "OST011"
    ],
    "account": [
      "1",
      "2",
      "3",
      "7"
    ],
    "productActive": true
  },
  {
    "productType": "PRT003",
    "name": "Bond Support Scheme",
    "shortName": "BSS",
    "configuration": {
      "commitmentDate": "NOT_APPLICABLE",
      "issuedDate": "NOT_APPLICABLE",
      "effectiveDate": "REQUIRED",
      "availabilityEndDate": "NOT_APPLICABLE",
      "expiryDate": "REQUIRED",
      "creditType": "TERM",
      "instrumentType": "Guarantee",
      "participations": "NOT_APPLICABLE",
      "scheduledRepayments": "NOT_APPLICABLE",
      "nonCashObligations": "NOT_APPLICABLE",
      "cashObligations": "NOT_APPLICABLE",
      "accrualSchedule": "NOT_APPLICABLE",
      "pimOwner": "NOT_APPLICABLE",
      "riskRating": "NOT_APPLICABLE",
      "preCreditPeriod": "NOT_APPLICABLE",
      "creditPeriod": "NOT_APPLICABLE",
      "lossGivenDefault": "NOT_APPLICABLE",
      "provisionRate": "NOT_APPLICABLE",
      "forecastYear": "NOT_APPLICABLE",
      "bankRate": "NOT_APPLICABLE",
      "repaymentType": "Bullet",
      "fees": {
        "creation": "NOT_APPLICABLE",
        "inLife": "OPTIONAL"
      },
      "obligations": {
        "creation": "REQUIRED",
        "inLife": "OPTIONAL"
      },
      "reinsurance": {
        "creation": "NOT_APPLICABLE",
        "inLife": "NOT_APPLICABLE"
      },
      "leadDays": {
        "repayments": 5,
        "interestAccruals": 5,
        "accruingFees": 1
      }
    },
    "additionalRates": [
      "ARTOTH"
    ],
    "accrualSchedules": [
      {
        "code": "PAC01",
        "cashIndicator": true
      }
    ],
    "baseRates": [
      "BRTOTH"
    ],
    "counterpartyRoleTypes": [
      "CRT004",
      "CRT005",
      "CRT040"
    ],
    "facilityCategoryTypes": [],
    "feeTypes": [],
    "obligationSubtypes": [
      "OST012",
      "OST013",
      "OST014",
      "OST015",
      "OST016",
      "OST017",
      "OST018",
      "OST019",
      "OST020",
      "OST021",
      "OST022"
    ],
    "account": [
      "2"
    ],
    "productActive": true
  },
  {
    "productType": "PRT004",
    "name": "General Export Facility",
    "shortName": "GEF",
    "configuration": {
      "commitmentDate": "NOT_APPLICABLE",
      "issuedDate": "NOT_APPLICABLE",
      "effectiveDate": "REQUIRED",
      "availabilityEndDate": "NOT_APPLICABLE",
      "expiryDate": "REQUIRED",
      "creditType": "REVOLVER",
      "instrumentType": "Guarantee",
      "participations": "NOT_APPLICABLE",
      "scheduledRepayments": "NOT_APPLICABLE",
      "nonCashObligations": "NOT_APPLICABLE",
      "cashObligations": "NOT_APPLICABLE",
      "accrualSchedule": "NOT_APPLICABLE",
      "pimOwner": "NOT_APPLICABLE",
      "riskRating": "NOT_APPLICABLE",
      "preCreditPeriod": "NOT_APPLICABLE",
      "creditPeriod": "NOT_APPLICABLE",
      "lossGivenDefault": "NOT_APPLICABLE",
      "provisionRate": "NOT_APPLICABLE",
      "forecastYear": "NOT_APPLICABLE",
      "bankRate": "NOT_APPLICABLE",
      "repaymentType": "Bullet",
      "fees": {
        "creation": "NOT_APPLICABLE",
        "inLife": "OPTIONAL"
      },
      "obligations": {
        "creation": "REQUIRED",
        "inLife": "OPTIONAL"
      },
      "reinsurance": {
        "creation": "NOT_APPLICABLE",
        "inLife": "NOT_APPLICABLE"
      },
      "leadDays": {
        "repayments": 5,
        "interestAccruals": 5,
        "accruingFees": 1
      }
    },
    "additionalRates": [
      "ARTOTH"
    ],
    "accrualSchedules": [
      {
        "code": "PAC01",
        "cashIndicator": true
      }
    ],
    "baseRates": [
      "BRTOTH"
    ],
    "counterpartyRoleTypes": [
      "CRT043"
    ],
    "facilityCategoryTypes": [
      "FCT006",
      "FCT007"
    ],
    "feeTypes": [],
    "obligationSubtypes": [],
    "account": [
      "2"
    ],
    "productActive": true
  },
  {
    "productType": "PRT009",
    "name": "Direct Lending Loan",
    "shortName": "DL Loan",
    "configuration": {
      "commitmentDate": "NOT_APPLICABLE",
      "issuedDate": "REQUIRED",
      "effectiveDate": "OPTIONAL",
      "availabilityEndDate": "REQUIRED",
      "expiryDate": "REQUIRED",
      "creditType": "TERM",
      "instrumentType": "Cash Advance",
      "participations": "NOT_APPLICABLE",
      "scheduledRepayments": "NOT_APPLICABLE",
      "nonCashObligations": "NOT_APPLICABLE",
      "cashObligations": "NOT_APPLICABLE",
      "accrualSchedule": "NOT_APPLICABLE",
      "pimOwner": "NOT_APPLICABLE",
      "riskRating": "NOT_APPLICABLE",
      "preCreditPeriod": "NOT_APPLICABLE",
      "creditPeriod": "NOT_APPLICABLE",
      "lossGivenDefault": "NOT_APPLICABLE",
      "provisionRate": "NOT_APPLICABLE",
      "forecastYear": "NOT_APPLICABLE",
      "bankRate": "NOT_APPLICABLE",
      "repaymentType": "Scheduled",
      "fees": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "obligations": {
        "creation": "OPTIONAL",
        "inLife": "OPTIONAL"
      },
      "reinsurance": {
        "creation": "NOT_APPLICABLE",
        "inLife": "NOT_APPLICABLE"
      },
      "leadDays": {
        "repayments": 5,
        "interestAccruals": 5,
        "accruingFees": 5
      }
    },
    "additionalRates": [
      "ARTCAS",
      "ARTOTH",
      "ARTPEN",
      "ARTRAC"
    ],
    "accrualSchedules": [
      {
        "code": "CTL01",
        "cashIndicator": true
      },
      {
        "code": "PAC01",
        "cashIndicator": true
      },
      {
        "code": "PEN01",
        "cashIndicator": true
      }
    ],
    "baseRates": [
      "BRTCIRR",
      "BRTNLF",
      "BRTOTH"
    ],
    "counterpartyRoleTypes": [
      "CRT013",
      "CRT014",
      "CRT045"
    ],
    "facilityCategoryTypes": [],
    "feeTypes": [
      "CMF",
      "PLA"
    ],
    "obligationSubtypes": [
      "OST023",
      "OST024",
      "OST025",
      "OST026"
    ],
    "account": [
      "5"
    ],
    "productActive": true
  }
]
  ```

</details>
