### PR TITLE
feat(GIFT-25266): add endpoint for rate tickers

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -47,6 +47,7 @@
     "ESTR",
     "EWCS",
     "EXIP",
+    "FREQEBD",
     "Govuk",
     "hjlnp",
     "HJLNP",

--- a/src/constants/examples/examples.constant.ts
+++ b/src/constants/examples/examples.constant.ts
@@ -219,6 +219,18 @@ export const EXAMPLES = {
         non_working_day_date: BUSINESS_CENTRE.NON_WORKING_DAY.DATE,
       },
     ],
+    INTEREST_RATE_TICKERS: [
+      {
+        code: 'EUR001',
+        name: 'ESTR Overnight Daily Compounding (5-day lag)',
+        type: 'Compounding Rate',
+        frequencyCode: 'FREQEBD',
+        frequencyName: 'Every Business Day',
+        leadDays: 5,
+        currencyCode: 'EUR',
+        active: true,
+      },
+    ],
     PRODUCT_CONFIG: {
       BIP: {
         productType: PRODUCT_TYPES.BIP,

--- a/src/helpers/map-dom-interest-rate-tickers.test.ts
+++ b/src/helpers/map-dom-interest-rate-tickers.test.ts
@@ -1,0 +1,50 @@
+import { GetDomInterestRateTickersDomResponseDto } from '@ukef/modules/dom/dto/get-dom-interest-rate-tickers-dom-response.dto';
+
+import { mapDomInterestRateTickers } from './map-dom-interest-rate-tickers';
+
+describe('mapDomInterestRateTickers', () => {
+  it('should return an array of mapped interest rate tickers', () => {
+    // Arrange
+    const mockTicker: GetDomInterestRateTickersDomResponseDto = {
+      interest_rate_ticker_code: 'EUR001',
+      interest_rate_ticker_name: 'ESTR Overnight Daily Compounding (5-day lag)',
+      interest_rate_ticker_type: 'Compounding Rate',
+      interest_rate_frequency_code: 'FREQEBD',
+      interest_rate_frequency_name: 'Every Business Day',
+      interest_rate_ticker_lead_days: 5,
+      currency_code: 'EUR',
+      interest_rate_ticker_active_flag: true,
+    };
+    const mockTickers = [mockTicker];
+
+    // Act
+    const result = mapDomInterestRateTickers(mockTickers);
+
+    // Assert
+    const expected = [
+      {
+        code: mockTicker.interest_rate_ticker_code,
+        name: mockTicker.interest_rate_ticker_name,
+        type: mockTicker.interest_rate_ticker_type,
+        frequencyCode: mockTicker.interest_rate_frequency_code,
+        frequencyName: mockTicker.interest_rate_frequency_name,
+        leadDays: mockTicker.interest_rate_ticker_lead_days,
+        currencyCode: mockTicker.currency_code,
+        active: mockTicker.interest_rate_ticker_active_flag,
+      },
+    ];
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return an empty array when given an empty array', () => {
+    // Arrange
+    const mockTickers: GetDomInterestRateTickersDomResponseDto[] = [];
+
+    // Act
+    const result = mapDomInterestRateTickers(mockTickers);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});

--- a/src/helpers/map-dom-interest-rate-tickers.ts
+++ b/src/helpers/map-dom-interest-rate-tickers.ts
@@ -1,0 +1,14 @@
+import { GetDomInterestRateTickersDomResponseDto } from '@ukef/modules/dom/dto/get-dom-interest-rate-tickers-dom-response.dto';
+import { GetDomInterestRateTickersResponseDto } from '@ukef/modules/dom/dto/get-dom-interest-rate-tickers-response.dto';
+
+export const mapDomInterestRateTickers = (interestRateTickers: GetDomInterestRateTickersDomResponseDto[]): GetDomInterestRateTickersResponseDto[] =>
+  interestRateTickers.map((interestRateTicker) => ({
+    code: interestRateTicker.interest_rate_ticker_code,
+    name: interestRateTicker.interest_rate_ticker_name,
+    type: interestRateTicker.interest_rate_ticker_type,
+    frequencyCode: interestRateTicker.interest_rate_frequency_code,
+    frequencyName: interestRateTicker.interest_rate_frequency_name,
+    leadDays: interestRateTicker.interest_rate_ticker_lead_days,
+    currencyCode: interestRateTicker.currency_code,
+    active: interestRateTicker.interest_rate_ticker_active_flag,
+  }));

--- a/src/modules/dom/dom.controller.ts
+++ b/src/modules/dom/dom.controller.ts
@@ -18,6 +18,7 @@ import {
   GetDomProductConfigResponse,
   GetOdsBusinessCentreOdsResponsesNonWorkingDaysParamDto,
 } from './dto';
+import { GetDomInterestRateTickersResponseDto } from './dto/get-dom-interest-rate-tickers-response.dto';
 import { CreditRiskRatingEntity } from './entities';
 
 const { domOdsVersioning } = AppConfig();
@@ -135,6 +136,21 @@ export class DomController {
   })
   getCreditRiskRatings(): Promise<CreditRiskRatingEntity[]> {
     return this.creditRiskRatingsService.getAll();
+  }
+
+  @Get('interest-rate-tickers')
+  @ApiOperation({
+    summary: 'Get all interest rate tickers',
+  })
+  @ApiOkResponse({
+    description: 'All interest rate tickers',
+    type: [GetDomInterestRateTickersResponseDto],
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  getInterestRateTickers(): Promise<GetDomInterestRateTickersResponseDto[]> {
+    return this.odsService.getInterestRateTickers();
   }
 
   @Get('product-configuration/:productType')

--- a/src/modules/dom/dom.service.ts
+++ b/src/modules/dom/dom.service.ts
@@ -14,8 +14,6 @@ import {
 /**
  * DOM service.
  * This is responsible for all DOM operations.
- * NOTE: This service does not actually call DOM, all data is stored in APIM MDM.
- * In the future, this will be updated to call DOM.
  */
 @Injectable()
 export class DomService {

--- a/src/modules/dom/dto/get-dom-interest-rate-tickers-dom-response.dto.ts
+++ b/src/modules/dom/dto/get-dom-interest-rate-tickers-dom-response.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EXAMPLES } from '@ukef/constants';
+
+/**
+ * The response received from the ODS query for DOM interest rate tickers.
+ */
+export class GetDomInterestRateTickersDomResponseDto {
+  @ApiProperty({
+    description: 'The code of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].code,
+  })
+  readonly interest_rate_ticker_code: string;
+
+  @ApiProperty({
+    description: 'The name of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].name,
+  })
+  readonly interest_rate_ticker_name: string;
+
+  @ApiProperty({
+    description: 'The type of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].type,
+  })
+  readonly interest_rate_ticker_type: string;
+
+  @ApiProperty({
+    description: 'The code of the interest rate frequency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].frequencyCode,
+  })
+  readonly interest_rate_frequency_code: string;
+
+  @ApiProperty({
+    description: 'The name of the interest rate frequency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].frequencyName,
+  })
+  readonly interest_rate_frequency_name: string;
+
+  @ApiProperty({
+    description: 'The number of lead days for the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].leadDays,
+  })
+  readonly interest_rate_ticker_lead_days: number;
+
+  @ApiProperty({
+    description: 'The code of the currency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].currencyCode,
+  })
+  readonly currency_code: string;
+
+  @ApiProperty({
+    description: 'Whether the interest rate ticker is active',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].active,
+  })
+  readonly interest_rate_ticker_active_flag: boolean;
+}

--- a/src/modules/dom/dto/get-dom-interest-rate-tickers-response.dto.ts
+++ b/src/modules/dom/dto/get-dom-interest-rate-tickers-response.dto.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EXAMPLES } from '@ukef/constants';
+
+/**
+ * The response DTO for the GET /dom/interest-rate-tickers endpoint.
+ * This is mapped from the response received from the ODS query for DOM interest rate tickers in {@link GetDomInterestRateTickersDomResponseDto}.
+ */
+export class GetDomInterestRateTickersResponseDto {
+  @ApiProperty({
+    description: 'The code of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].code,
+  })
+  readonly code: string;
+
+  @ApiProperty({
+    description: 'The name of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].name,
+  })
+  readonly name: string;
+
+  @ApiProperty({
+    description: 'The type of the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].type,
+  })
+  readonly type: string;
+
+  @ApiProperty({
+    description: 'The code of the interest rate frequency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].frequencyCode,
+  })
+  readonly frequencyCode: string;
+
+  @ApiProperty({
+    description: 'The name of the interest rate frequency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].frequencyName,
+  })
+  readonly frequencyName: string;
+
+  @ApiProperty({
+    description: 'The number of lead days for the interest rate ticker',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].leadDays,
+  })
+  readonly leadDays: number;
+
+  @ApiProperty({
+    description: 'The code of the currency',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].currencyCode,
+  })
+  readonly currencyCode: string;
+
+  @ApiProperty({
+    description: 'Whether the interest rate ticker is active',
+    example: EXAMPLES.DOM.INTEREST_RATE_TICKERS[0].active,
+  })
+  readonly active: boolean;
+}

--- a/src/modules/ods/dto/ods-payloads.dto.ts
+++ b/src/modules/ods/dto/ods-payloads.dto.ts
@@ -61,12 +61,12 @@ export type OdsStoredProcedureInput = {
  * Stored Procedure output definition can be found here:
  * https://github.com/UK-Export-Finance/database-ods-datateam/blob/dev/t_apim/Stored%20Procedures/sp_ODS_query.sql#L279-L286
  */
-export type OdsStoredProcedureOutputBody = {
+export type OdsStoredProcedureOutputBody<TResult = Record<string, any>[]> = {
   query_request_id: string;
   message: string;
   status: 'SUCCESS' | 'ERROR';
   total_result_count: number;
-  results: Record<string, any>[];
+  results: TResult;
 };
 
 export const ODS_ENTITIES = {
@@ -84,6 +84,7 @@ export const ODS_ENTITIES = {
   FACILITY_CLASSIFICATION: 'facility_classification',
   OBLIGATION_CLASSIFICATION: 'obligation_classification',
   INDUSTRY: 'industry',
+  INTEREST_RATE_TICKER: 'interest_rate_ticker',
   SIC_CODE_TO_UKEF_INDUSTRY: 'map_sic_code_to_ukef_industry',
 } as const;
 

--- a/src/modules/ods/ods.service-getInterestRateTickers.test.ts
+++ b/src/modules/ods/ods.service-getInterestRateTickers.test.ts
@@ -1,0 +1,110 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { EXAMPLES, STORED_PROCEDURE } from '@ukef/constants';
+import { mapDomInterestRateTickers } from '@ukef/helpers/map-dom-interest-rate-tickers';
+import { PinoLogger } from 'nestjs-pino';
+import { DataSource, QueryRunner } from 'typeorm';
+
+import { ODS_ENTITIES, OdsStoredProcedureInput } from './dto/ods-payloads.dto';
+import { OdsService } from './ods.service';
+import { OdsStoredProcedureService } from './ods-stored-procedure.service';
+
+describe('OdsService - getInterestRateTickers', () => {
+  let service: OdsService;
+  let odsStoredProcedureService: OdsStoredProcedureService;
+  let mockQueryRunner: jest.Mocked<QueryRunner>;
+  let mockDataSource: jest.Mocked<DataSource>;
+  const mockLogger = new PinoLogger({});
+
+  const [exampleTicker] = EXAMPLES.DOM.INTEREST_RATE_TICKERS;
+
+  beforeEach(() => {
+    mockQueryRunner = {
+      query: jest.fn(),
+      release: jest.fn(),
+    } as unknown as jest.Mocked<QueryRunner>;
+
+    mockDataSource = {
+      createQueryRunner: jest.fn().mockReturnValue(mockQueryRunner),
+    } as unknown as jest.Mocked<DataSource>;
+
+    odsStoredProcedureService = new OdsStoredProcedureService(mockDataSource);
+    service = new OdsService(odsStoredProcedureService, mockLogger);
+  });
+
+  const mockStoredProcedureOutput = `{
+    "message": "${STORED_PROCEDURE.SUCCESS}",
+    "status": "${STORED_PROCEDURE.SUCCESS}",
+    "total_result_count": 1,
+    "results": [
+      {
+        "interest_rate_ticker_code": "${exampleTicker.code}",
+        "interest_rate_ticker_name": "${exampleTicker.name}",
+        "interest_rate_ticker_type": "${exampleTicker.type}",
+        "interest_rate_frequency_code": "${exampleTicker.frequencyCode}",
+        "interest_rate_frequency_name": "${exampleTicker.frequencyName}",
+        "interest_rate_ticker_lead_days": ${exampleTicker.leadDays},
+        "currency_code": "${exampleTicker.currencyCode}",
+        "interest_rate_ticker_active_flag": ${exampleTicker.active}
+      }
+    ]
+  }`;
+
+  beforeEach(() => {
+    jest.spyOn(odsStoredProcedureService, 'call').mockResolvedValue(mockStoredProcedureOutput);
+  });
+
+  it('should call odsStoredProcedureService.call', async () => {
+    // Act
+    await service.getInterestRateTickers();
+
+    // Assert
+    const expectedStoredProcedureInput: OdsStoredProcedureInput = odsStoredProcedureService.createInput({
+      entityToQuery: ODS_ENTITIES.INTEREST_RATE_TICKER,
+    });
+
+    expect(odsStoredProcedureService.call).toHaveBeenCalledTimes(1);
+    expect(odsStoredProcedureService.call).toHaveBeenCalledWith(expectedStoredProcedureInput);
+  });
+
+  it('should return mapped interest rate tickers', async () => {
+    // Act
+    const result = await service.getInterestRateTickers();
+
+    // Assert
+    const jsonResults = JSON.parse(mockStoredProcedureOutput).results;
+
+    const expected = mapDomInterestRateTickers(jsonResults);
+
+    expect(result).toEqual(expected);
+  });
+
+  describe(`when the response from ODS does not have status as ${STORED_PROCEDURE.SUCCESS}`, () => {
+    it('should throw an error', async () => {
+      // Arrange
+      const invalidOutput = `{ "status": "NOT ${STORED_PROCEDURE.SUCCESS}" }`;
+
+      jest.spyOn(odsStoredProcedureService, 'call').mockResolvedValue(invalidOutput);
+
+      // Act & Assert
+      const promise = service.getInterestRateTickers();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      await expect(promise).rejects.toThrow('Error getting interest rate tickers from ODS');
+    });
+  });
+
+  describe('when call throws an error', () => {
+    it('should throw an error', async () => {
+      // Arrange
+      jest.spyOn(odsStoredProcedureService, 'call').mockRejectedValue('Mock ODS error');
+
+      // Act & Assert
+      const promise = service.getInterestRateTickers();
+
+      await expect(promise).rejects.toBeInstanceOf(InternalServerErrorException);
+
+      await expect(promise).rejects.toThrow('Error getting interest rate tickers from ODS');
+    });
+  });
+});

--- a/src/modules/ods/ods.service.ts
+++ b/src/modules/ods/ods.service.ts
@@ -550,14 +550,14 @@ export class OdsService {
       if (storedProcedureJson?.status !== STORED_PROCEDURE.SUCCESS) {
         this.logger.error('Error getting interest rate tickers from ODS stored procedure, output %o', storedProcedureResult);
 
-        throw new InternalServerErrorException('Error getting interest rate tickers from ODS stored procedure');
+        throw new Error('Error getting interest rate tickers from ODS stored procedure');
       }
 
       return mapDomInterestRateTickers(storedProcedureJson.results);
     } catch (error) {
       this.logger.error('Error getting interest rate tickers from ODS %o', error);
 
-      throw new InternalServerErrorException('Error getting interest rate tickers from ODS');
+      throw new InternalServerErrorException('Error getting interest rate tickers from ODS', { cause: error });
     }
   }
 }

--- a/src/modules/ods/ods.service.ts
+++ b/src/modules/ods/ods.service.ts
@@ -1,9 +1,12 @@
 import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { COMPANIES, STORED_PROCEDURE } from '@ukef/constants';
 import { mapBusinessCentre, mapBusinessCentres, mapFeeType, mapFeeTypes, mapIndustries, mapIndustry, mapIndustryCodes } from '@ukef/helpers';
+import { mapDomInterestRateTickers } from '@ukef/helpers/map-dom-interest-rate-tickers';
 import { PinoLogger } from 'nestjs-pino';
 
 import { FindOdsBusinessCentreOdsResponse } from '../dom/dto';
+import { GetDomInterestRateTickersDomResponseDto } from '../dom/dto/get-dom-interest-rate-tickers-dom-response.dto';
+import { GetDomInterestRateTickersResponseDto } from '../dom/dto/get-dom-interest-rate-tickers-response.dto';
 import {
   GetFeeTypeOdsResponseDto,
   GetFeeTypeResponseDto,
@@ -529,6 +532,32 @@ export class OdsService {
       }
 
       throw new InternalServerErrorException(`Error finding UKEF industry code by Companies House industry code ${industryCode} in ODS`, { cause: error });
+    }
+  }
+
+  async getInterestRateTickers(): Promise<GetDomInterestRateTickersResponseDto[]> {
+    try {
+      this.logger.info('Getting interest rate tickers from ODS');
+
+      const storedProcedureInput = this.odsStoredProcedureService.createInput({
+        entityToQuery: ODS_ENTITIES.INTEREST_RATE_TICKER,
+      });
+
+      const storedProcedureResult = await this.odsStoredProcedureService.call(storedProcedureInput);
+
+      const storedProcedureJson: OdsStoredProcedureOutputBody<GetDomInterestRateTickersDomResponseDto[]> = JSON.parse(storedProcedureResult);
+
+      if (storedProcedureJson?.status !== STORED_PROCEDURE.SUCCESS) {
+        this.logger.error('Error getting interest rate tickers from ODS stored procedure, output %o', storedProcedureResult);
+
+        throw new InternalServerErrorException('Error getting interest rate tickers from ODS stored procedure');
+      }
+
+      return mapDomInterestRateTickers(storedProcedureJson.results);
+    } catch (error) {
+      this.logger.error('Error getting interest rate tickers from ODS %o', error);
+
+      throw new InternalServerErrorException('Error getting interest rate tickers from ODS');
     }
   }
 }

--- a/test/dom/dom-interest-rate-tickers.api-test.ts
+++ b/test/dom/dom-interest-rate-tickers.api-test.ts
@@ -1,0 +1,45 @@
+import { HttpStatus } from '@nestjs/common';
+import AppConfig from '@ukef/config/app.config';
+import { Api } from '@ukef-test/support/api';
+
+const {
+  domOdsVersioning: { prefixAndVersion },
+} = AppConfig();
+
+describe('/dom - interest rate tickers', () => {
+  let api: Api;
+
+  beforeAll(async () => {
+    api = await Api.create();
+  });
+
+  afterAll(async () => {
+    await api.destroy();
+  });
+
+  it(`should return ${HttpStatus.OK}`, async () => {
+    // Arrange
+    const url = `/api/${prefixAndVersion}/dom/interest-rate-tickers`;
+
+    // Act
+    const { status, body } = await api.get(url);
+
+    // Assert
+    expect(status).toBe(HttpStatus.OK);
+
+    const expected = expect.arrayContaining([
+      expect.objectContaining({
+        code: expect.any(String),
+        name: expect.any(String),
+        type: expect.any(String),
+        frequencyCode: expect.any(String),
+        frequencyName: expect.any(String),
+        leadDays: expect.any(Number),
+        currencyCode: expect.any(String),
+        active: expect.any(Boolean),
+      }),
+    ]);
+
+    expect(body).toEqual(expected);
+  });
+});


### PR DESCRIPTION
# Introduction :pencil2:

Create a new endpoint to return the interest rate tickers from DOM


## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```bash
curl -X 'GET' \
  'http://localhost:5010/api/v2/dom/interest-rate-tickers' \
  -H 'accept: application/json' \
  -H 'x-api-key: test'
```

  ```json
   [
  {
    "code": "EUR001",
    "name": "ESTR Overnight Daily Compounding (5-day lag)",
    "type": "Compounding Rate",
    "frequencyCode": "FREQEBD",
    "frequencyName": "Every Business Day",
    "leadDays": 5,
    "currencyCode": "EUR",
    "active": true
  },
  {
    "code": "EUR002",
    "name": "ESTR Overnight Daily Simple (5-day lag)",
    "type": "Simple Rate",
    "frequencyCode": "FREQEBD",
    "frequencyName": "Every Business Day",
    "leadDays": 5,
    "currencyCode": "EUR",
    "active": true
  },
  {
    "code": "EUR003",
    "name": "Euribor 3-Month Term",
    "type": "Term Rate",
    "frequencyCode": "FREQ3MON",
    "frequencyName": "Quarterly",
    "leadDays": 2,
    "currencyCode": "EUR",
    "active": true
  },
  {
    "code": "EUR004",
    "name": "Euribor 6-Month Term",
    "type": "Term Rate",
    "frequencyCode": "FREQ6MON",
    "frequencyName": "Semi-annually",
    "leadDays": 2,
    "currencyCode": "EUR",
    "active": true
  }
]
  ```

</details>
