### PR TITLE
feat(GIFT-25470): add fields to fee response

### DIFF
--- a/src/constants/examples/examples.constant.ts
+++ b/src/constants/examples/examples.constant.ts
@@ -40,6 +40,8 @@ const FEE_TYPE = {
   BASE_BALANCE_CATEGORY: 'On facility available amount',
   NON_FACILITY_CURRENCY_SETTLEMENT: false,
   CAPPED_BASE_BALANCE: false,
+  EFFECTIVE_DATE_DEFAULT: 'Facility Signed Date',
+  MATURITY_DATE_DEFAULT: 'Facility Availability End Date',
 };
 
 const INDUSTRY = {
@@ -409,6 +411,8 @@ export const EXAMPLES = {
       baseBalanceCategory: 'On Principal Drawn Amount',
       nonFacilityCurrencySettlement: false,
       feeTypeCappedBaseBalanceIndicator: false,
+      feeEffectiveDateDefault: 'Facility Signed Date',
+      feeMaturityDateDefault: 'Facility Availability End Date',
     },
     CONFIGURATION_FREQUENCY: {
       code: 'FREQ12MON',

--- a/src/helpers/map-fee-type.test.ts
+++ b/src/helpers/map-fee-type.test.ts
@@ -21,8 +21,28 @@ describe('mapFeeType', () => {
       baseBalanceCategory: mockFeeType.baseBalanceCategory ?? null,
       nonFacilityCurrencySettlement: mockFeeType.nonFacilityCurrencySettlement,
       cappedBaseBalance: mockFeeType.feeTypeCappedBaseBalanceIndicator,
+      effectiveDateDefault: mockFeeType.feeEffectiveDateDefault,
+      maturityDateDefault: mockFeeType.feeMaturityDateDefault,
     };
 
     expect(result).toEqual(expected);
+  });
+
+  it('should map missing date defaults to null', () => {
+    // Arrange
+    const mockFeeType = {
+      ...EXAMPLES.ODS.CONFIGURATION_FEE,
+      feeEffectiveDateDefault: undefined,
+      feeMaturityDateDefault: null,
+    };
+
+    // Act
+    const result = mapFeeType(mockFeeType);
+
+    // Assert
+    expect(result).toMatchObject({
+      effectiveDateDefault: null,
+      maturityDateDefault: null,
+    });
   });
 });

--- a/src/helpers/map-fee-type.ts
+++ b/src/helpers/map-fee-type.ts
@@ -15,4 +15,6 @@ export const mapFeeType = (feeType: GetFeeTypeOdsResponseDto): GetFeeTypeRespons
   baseBalanceCategory: feeType.baseBalanceCategory ?? null,
   nonFacilityCurrencySettlement: feeType.nonFacilityCurrencySettlement,
   cappedBaseBalance: feeType.feeTypeCappedBaseBalanceIndicator,
+  effectiveDateDefault: feeType.feeEffectiveDateDefault ?? null,
+  maturityDateDefault: feeType.feeMaturityDateDefault ?? null,
 });

--- a/src/modules/ods/dto/get-fee-type-ods-response.dto.ts
+++ b/src/modules/ods/dto/get-fee-type-ods-response.dto.ts
@@ -57,4 +57,18 @@ export class GetFeeTypeOdsResponseDto {
     example: EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeCappedBaseBalanceIndicator,
   })
   readonly feeTypeCappedBaseBalanceIndicator: boolean;
+
+  @ApiProperty({
+    description: 'What the effective date of the fee should default to if not specified',
+    example: EXAMPLES.ODS.CONFIGURATION_FEE.feeEffectiveDateDefault,
+    nullable: true,
+  })
+  readonly feeEffectiveDateDefault: string | null;
+
+  @ApiProperty({
+    description: 'What the maturity date of the fee should default to if not specified',
+    example: EXAMPLES.ODS.CONFIGURATION_FEE.feeMaturityDateDefault,
+    nullable: true,
+  })
+  readonly feeMaturityDateDefault: string | null;
 }

--- a/src/modules/ods/dto/get-fee-type-response.dto.ts
+++ b/src/modules/ods/dto/get-fee-type-response.dto.ts
@@ -57,4 +57,18 @@ export class GetFeeTypeResponseDto {
     example: EXAMPLES.FEE_TYPE.CAPPED_BASE_BALANCE,
   })
   readonly cappedBaseBalance: boolean;
+
+  @ApiProperty({
+    description: 'What the effective date of the fee should default to if not specified',
+    example: EXAMPLES.FEE_TYPE.EFFECTIVE_DATE_DEFAULT,
+    nullable: true,
+  })
+  readonly effectiveDateDefault: string | null;
+
+  @ApiProperty({
+    description: 'What the maturity date of the fee should default to if not specified',
+    example: EXAMPLES.FEE_TYPE.MATURITY_DATE_DEFAULT,
+    nullable: true,
+  })
+  readonly maturityDateDefault: string | null;
 }

--- a/src/modules/ods/ods.service-findFeeType.test.ts
+++ b/src/modules/ods/ods.service-findFeeType.test.ts
@@ -42,7 +42,9 @@ describe('OdsService - findFeeType', () => {
         "feeTypeActive": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeActive},
         "balanceCategory": "${EXAMPLES.ODS.CONFIGURATION_FEE.balanceCategory}",
         "nonFacilityCurrencySettlement": ${EXAMPLES.ODS.CONFIGURATION_FEE.nonFacilityCurrencySettlement},
-        "feeTypeCappedBaseBalanceIndicator": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeCappedBaseBalanceIndicator}
+        "feeTypeCappedBaseBalanceIndicator": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeCappedBaseBalanceIndicator},
+        "feeEffectiveDateDefault": "${EXAMPLES.ODS.CONFIGURATION_FEE.feeEffectiveDateDefault}",
+        "feeMaturityDateDefault": "${EXAMPLES.ODS.CONFIGURATION_FEE.feeMaturityDateDefault}"
       }
     ]
   }`;

--- a/src/modules/ods/ods.service-getFeeTypes.test.ts
+++ b/src/modules/ods/ods.service-getFeeTypes.test.ts
@@ -42,7 +42,9 @@ describe('OdsService - getFeeTypes', () => {
         "feeTypeActive": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeActive},
         "balanceCategory": "${EXAMPLES.ODS.CONFIGURATION_FEE.balanceCategory}",
         "nonFacilityCurrencySettlement": ${EXAMPLES.ODS.CONFIGURATION_FEE.nonFacilityCurrencySettlement},
-        "feeTypeCappedBaseBalanceIndicator": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeCappedBaseBalanceIndicator}
+        "feeTypeCappedBaseBalanceIndicator": ${EXAMPLES.ODS.CONFIGURATION_FEE.feeTypeCappedBaseBalanceIndicator},
+        "feeEffectiveDateDefault": "${EXAMPLES.ODS.CONFIGURATION_FEE.feeEffectiveDateDefault}",
+        "feeMaturityDateDefault": "${EXAMPLES.ODS.CONFIGURATION_FEE.feeMaturityDateDefault}"
       },
       {
         "feeType": "${EXAMPLES.ODS.CONFIGURATION_FEE.feeType}",
@@ -53,7 +55,9 @@ describe('OdsService - getFeeTypes', () => {
         "balanceCategory": "${EXAMPLES.ODS.CONFIGURATION_FEE.balanceCategory}",
         "baseBalanceCategory": "On Principal Drawn Amount",
         "nonFacilityCurrencySettlement": ${EXAMPLES.ODS.CONFIGURATION_FEE.nonFacilityCurrencySettlement},
-        "feeTypeCappedBaseBalanceIndicator": true
+        "feeTypeCappedBaseBalanceIndicator": true,
+        "feeEffectiveDateDefault": null,
+        "feeMaturityDateDefault": null
       }
     ]
   }`;

--- a/test/ods/ods.fee-types.api-test.ts
+++ b/test/ods/ods.fee-types.api-test.ts
@@ -40,6 +40,8 @@ describe('/ods - Fee types', () => {
           baseBalanceCategory: expect.anything(),
           nonFacilityCurrencySettlement: expect.any(Boolean),
           cappedBaseBalance: expect.any(Boolean),
+          effectiveDateDefault: expect.any(String),
+          maturityDateDefault: expect.any(String),
         }),
       ]);
 
@@ -68,6 +70,8 @@ describe('/ods - Fee types', () => {
         baseBalanceCategory: expect.anything(),
         nonFacilityCurrencySettlement: expect.any(Boolean),
         cappedBaseBalance: expect.any(Boolean),
+        effectiveDateDefault: expect.any(String),
+        maturityDateDefault: expect.any(String),
       });
 
       expect(body).toEqual(expected);


### PR DESCRIPTION
# Introduction :pencil2:

Add two new fields to the fee types response

## Resolution :heavy_check_mark:

- map fields
- update tests


## Request / response :eyes:

<details>
  <summary>Show/hide</summary>

```bash
curl -X 'GET' \
  'http://localhost:5010/api/v2/ods/fee-types' \
  -H 'accept: application/json' \
  -H 'x-api-key: test'
```

  ```json
   [
  {
    "feeType": "ABF",
    "name": "Agent Bank Fee",
    "classification": "Accruing",
    "expenseIncome": "Expense",
    "isActive": true,
    "balanceCategory": "ABF",
    "baseBalanceCategory": "On Limit Used",
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": true,
    "effectiveDateDefault": "Facility Effective Date",
    "maturityDateDefault": "Facility Maturity Date"
  },
  {
    "feeType": "BEX",
    "name": "Brokerage Expense",
    "classification": "Fixed",
    "expenseIncome": "Expense",
    "isActive": true,
    "balanceCategory": "BEX",
    "baseBalanceCategory": null,
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": null,
    "maturityDateDefault": null
  },
  {
    "feeType": "CMF",
    "name": "Commitment Fee",
    "classification": "Accruing",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "CMF",
    "baseBalanceCategory": "On Limit Available",
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": "Facility Signed Date",
    "maturityDateDefault": "Facility Availability End Date"
  },
  {
    "feeType": "COM",
    "name": "Commitment Fee (ASU 2011)",
    "classification": "Fixed",
    "expenseIncome": "Income",
    "isActive": false,
    "balanceCategory": "COM",
    "baseBalanceCategory": null,
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": null,
    "maturityDateDefault": null
  },
  {
    "feeType": "PAX",
    "name": "Premium Accrual Cross Currency",
    "classification": "Fixed",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "PAC",
    "baseBalanceCategory": null,
    "nonFacilityCurrencySettlement": true,
    "cappedBaseBalance": false,
    "effectiveDateDefault": null,
    "maturityDateDefault": null
  },
  {
    "feeType": "PLA",
    "name": "Premium Less Admin",
    "classification": "Fixed",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "PLA",
    "baseBalanceCategory": null,
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": null,
    "maturityDateDefault": null
  },
  {
    "feeType": "PRT",
    "name": "Participation Fee",
    "classification": "Accruing",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "PRT",
    "baseBalanceCategory": "On Limit Amount",
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": "Facility Effective Date",
    "maturityDateDefault": "Facility Maturity Date"
  },
  {
    "feeType": "SUP",
    "name": "Support Fee",
    "classification": "Fixed",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "SUP",
    "baseBalanceCategory": null,
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": null,
    "maturityDateDefault": null
  },
  {
    "feeType": "UTL",
    "name": "Utilisation Fee",
    "classification": "Accruing",
    "expenseIncome": "Income",
    "isActive": true,
    "balanceCategory": "UTL",
    "baseBalanceCategory": "On Limit Used",
    "nonFacilityCurrencySettlement": false,
    "cappedBaseBalance": false,
    "effectiveDateDefault": "Facility Effective Date",
    "maturityDateDefault": "Facility Maturity Date"
  }
]
  ```

</details>

